### PR TITLE
Getrennte Install-Configs für Windows und Linux

### DIFF
--- a/WoPeD-Installer/InstallFiles/install_linux.xml
+++ b/WoPeD-Installer/InstallFiles/install_linux.xml
@@ -32,16 +32,15 @@
 	</locale>
 
 	<resources>
-		<res id="LicencePanel.licence" src="License.txt"></res>
-		<res id="InfoPanel.info" src="Readme.txt"></res>
+		<res id="LicencePanel.licence" src="License.txt" />
+		<res id="InfoPanel.info" src="Readme.txt" />
 		<res id="Installer.image.0" src="helloPanel.png" />
 		<res id="Installer.image.1" src="infoPanel.png" />
 		<res id="Installer.image.2" src="licencePanel.png" />
 		<res id="Installer.image.3" src="packsPanel.png" />
 		<res id="Installer.image.4" src="targetPanel.png" />
-		<res id="Installer.image.5" src="installPanel.png" />
 		<res id="Installer.image.6" src="shortcutPanel.png" />
-		<res id="ProcessPanel.Spec.xml" src="process.xml" />
+		<res id="Installer.image.5" src="installPanel.png" />
 		<res id="Installer.image.7" src="finishPanel.png" />
 		<res id="installer.langsel.img" src="WoPeD-logo.jpg" />
 		<res id="packsLang.xml_eng" src="install-eng.xml" />
@@ -67,30 +66,20 @@
 		<panel classname="LicencePanel"></panel>
 		<panel classname="TargetPanel"></panel>
 		<panel classname="PacksPanel"></panel>
-		<panel classname="InstallPanel"></panel>
 		<panel classname="ShortcutPanel"></panel>
-		<panel classname="ProcessPanel"></panel>
+		<panel classname="InstallPanel"></panel>
 		<panel classname="SimpleFinishPanel"></panel>
 	</panels>
 
 	<packs>
 		<pack name="Executable" required="yes" id="id1">
 			<description>Executable files</description>
-
-			<fileset dir="." targetdir="${INSTALL_PATH}" override="true">
-				<include name="WoPeD.exe" />
-				<include name="Readme.txt" />
-				<include name="License.txt" />
-				<include name="Changelog.txt" />
-				<os family="windows" />
-			</fileset>
 			<fileset dir="." targetdir="${INSTALL_PATH}" override="true">
 				<include name="WoPeD-Starter.jar" />
 				<include name="Readme.txt" />
 				<include name="License.txt" />
 				<include name="Changelog.txt" />
 				<include name="WoPeD.png" />
-				<os family="unix" />
 			</fileset>
 		</pack>
 
@@ -112,6 +101,5 @@
 				<include name="doc/html/*" />
 			</fileset>
 		</pack>
-
 	</packs>
 </izpack:installation>

--- a/WoPeD-Installer/InstallFiles/install_windows.xml
+++ b/WoPeD-Installer/InstallFiles/install_windows.xml
@@ -1,0 +1,105 @@
+<izpack:installation version="5.0"
+	xmlns:izpack="http://izpack.org/schema/installation"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://izpack.org/schema/installation http://izpack.org/schema/5.0/izpack-installation-5.0.xsd">
+
+	<guiprefs width="640" height="560" resizable="no">
+		<modifier key="useHeadingPanel" value="yes" />
+		<modifier key="useHeadingForSummary" value="yes" />
+		<modifier key="headingLineCount" value="2" />
+		<modifier key="headingFontSize" value="1.5" />
+		<modifier key="headingBackgroundColor" value="0x00ffffff" />
+		<modifier key="headingPanelCounter" value="progressbar" />
+		<modifier key="headingPanelCounterPos"
+			value="inNavigationPanel" />
+		<modifier key="langDisplayType" value="native" />
+		<modifier key="layoutAnchor" value="NORTHWEST" />
+	</guiprefs>
+
+	<natives>
+		<native type="izpack" name="ShellLink.dll">
+			<os family="windows" />
+		</native>
+
+		<native type="izpack" name="ShellLink_x64.dll">
+			<os family="windows" />
+		</native>
+	</natives>
+
+	<locale>
+		<langpack iso3="eng" />
+		<langpack iso3="deu" />
+	</locale>
+	
+	<resources>
+		<res id="LicencePanel.licence" src="License.txt" />
+		<res id="InfoPanel.info" src="Readme.txt" />
+		<res id="Installer.image.0" src="helloPanel.png" />
+		<res id="Installer.image.1" src="infoPanel.png" />
+		<res id="Installer.image.2" src="licencePanel.png" />
+		<res id="Installer.image.3" src="packsPanel.png" />
+		<res id="Installer.image.4" src="targetPanel.png" />
+		<res id="Installer.image.6" src="shortcutPanel.png" />
+		<res id="Installer.image.5" src="installPanel.png" />
+		<res id="Installer.image.7" src="finishPanel.png" />
+		<res id="installer.langsel.img" src="WoPeD-logo.jpg" />
+		<res id="packsLang.xml_eng" src="install-eng.xml" />
+		<res id="packsLang.xml_deu" src="install-deu.xml" />
+		<res id="shortcutSpec.xml" src="shortcut-win.xml" />
+		<res id="Unix_shortcutSpec.xml" src="shortcut-unix.xml" />
+	</resources>
+
+	<info>
+		<appname>WoPeD</appname>
+		<appversion>@{woped.version}</appversion>
+		<authors>
+			<author name="Responsible: Thomas Freytag"
+				email="info@woped.org"></author>
+		</authors>
+		<url>http://www.woped.org</url>
+		<pack200>lzma</pack200>
+	</info>
+
+	<panels>
+		<panel classname="HelloPanel"></panel>
+		<panel classname="InfoPanel"></panel>
+		<panel classname="LicencePanel"></panel>
+		<panel classname="TargetPanel"></panel>
+		<panel classname="PacksPanel"></panel>
+		<panel classname="ShortcutPanel"></panel>
+		<panel classname="InstallPanel"></panel>
+		<panel classname="SimpleFinishPanel"></panel>
+	</panels>
+
+	<packs>
+		<pack name="Executable" required="yes" id="id1">
+			<description>Executable files</description>
+
+			<fileset dir="." targetdir="${INSTALL_PATH}" override="true">
+				<include name="WoPeD.exe" />
+				<include name="Readme.txt" />
+				<include name="License.txt" />
+				<include name="Changelog.txt" />
+			</fileset>
+		</pack>
+
+		<pack name="PDF Documentation" required="no" id="id2">
+			<description>Additional manual and user doc files</description>
+
+			<fileset dir="." targetdir="${INSTALL_PATH}/doc"
+				override="true">
+				<include name="doc/pdf/de/*" />
+				<include name="doc/pdf/en/*" />
+			</fileset>
+		</pack>
+
+		<pack name="HTML Manual" required="no" id="id3">
+			<description>Separate HTML Manual files</description>
+
+			<fileset dir="." targetdir="${INSTALL_PATH}/doc"
+				override="true">
+				<include name="doc/html/*" />
+			</fileset>
+		</pack>
+	</packs>
+</izpack:installation>

--- a/WoPeD-Installer/pom.xml
+++ b/WoPeD-Installer/pom.xml
@@ -134,15 +134,32 @@
 					<artifactId>izpack-maven-plugin</artifactId>
 					<version>5.1.3</version>
 					<executions>
+					<!-- Step 3.1: Installer für Windows erzeugen -> Wird im nächsten Schritt in eine Exe gepackt-->
 						<execution>
 							<phase>prepare-package</phase>
+							<id>windows</id>
 							<goals>
 								<goal>izpack</goal>
 							</goals>
 							<configuration>
 								<baseDir>./target/staging</baseDir>
-								<installFile>./target/staging/install.xml</installFile>
+								<installFile>./target/staging/install_windows.xml</installFile>
 								<output>./target/stagingOutput/WoPeD-Installer.jar</output>
+								<!-- Benötigt für Update auf IzPack 5.1.3 https://stackoverflow.com/questions/52870386/an-attached-artifact-must-have-a-different-id-than-its-corresponding-main-artifa/53132888 -->
+								<classifier>BugFix</classifier>
+							</configuration>
+						</execution>
+						<!-- Step 3.2: Installer für Linux erzeugen und direkt in dem Linux-Output-Ordner ablegen -->
+						<execution>
+							<phase>prepare-package</phase>
+							<id>linux</id>
+							<goals>
+								<goal>izpack</goal>
+							</goals>
+							<configuration>
+								<baseDir>./target/staging</baseDir>
+								<installFile>./target/staging/install_linux.xml</installFile>
+								<output>./target/Linux/WoPeD-Installer.jar</output>
 								<!-- Benötigt für Update auf IzPack 5.1.3 https://stackoverflow.com/questions/52870386/an-attached-artifact-must-have-a-different-id-than-its-corresponding-main-artifa/53132888 -->
 								<classifier>BugFix</classifier>
 							</configuration>


### PR DESCRIPTION
Ich habe in WoPeD-Install seperate Installations-Configs für Windows und Linux angelegt.
So werden diese Installer in verschiedenen Schritten gebaut und sind sauber voneinander getrennt. Die größe der Installer hat sich so auch halbiert. 