### PR TITLE
YAWLExport Erweiterung der Dateiformate beim Speichern um yawl #120

### DIFF
--- a/WoPeD-BeanConfiguration/src/main/java/org/woped/beanconfiguration/configuration.xsd
+++ b/WoPeD-BeanConfiguration/src/main/java/org/woped/beanconfiguration/configuration.xsd
@@ -17,20 +17,22 @@
 			</xs:all>
 		</xs:complexType>
 	</xs:element>
-	
+
 	<xs:complexType name="Importing">
 		<xs:sequence>
 			<xs:element name="toolspecific" type="xs:boolean"/>
 		</xs:sequence>
 	</xs:complexType>
-	
+
 	<xs:complexType name="Exporting">
 		<xs:sequence>
 			<xs:element name="toolspecific" type="xs:boolean"/>
 			<xs:element name="tpnExportElementAsName" type="xs:boolean" default="1"/>
+			<xs:element name="yawlExportExplicitPlaces" type="xs:boolean"/>
+			<xs:element name="yawlExportGroups" type="xs:boolean"/>
 		</xs:sequence>
 	</xs:complexType>
-	
+
 	<xs:complexType name="GUI">
 		<xs:sequence>
 			<xs:element name="Window">
@@ -90,18 +92,19 @@
 			<xs:element name="aproManagerPath" type="xs:string" minOccurs="0" />
 			<xs:element name="aproUserName" type="xs:string" minOccurs="0" />
 			<xs:element name="aproPassword" type="xs:string" minOccurs="0" />
-			<xs:element name="aproUseProxy" type="xs:boolean" minOccurs="0" />			
+			<xs:element name="aproUseProxy" type="xs:boolean" minOccurs="0" />
 			<xs:element name="aproProxyName" type="xs:string" minOccurs="0" />
 			<xs:element name="aproProxyPort" type="xs:int" minOccurs="0" />
+			<xs:element name="yawlEnabled" type="xs:boolean" minOccurs="0" />
 		</xs:sequence>
 	</xs:complexType>
-	
+
 	<xs:complexType name="ApromoreServers">
 		<xs:sequence>
 			<xs:element name="apromoreServer" 	type="ApromoreServer" 	minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
-	
+
 	<xs:complexType name="ApromoreServer">
 		<xs:sequence>
 			<xs:element name="apromoreServerID" 	type="xs:int" 		minOccurs="1" 		maxOccurs="1"/>
@@ -111,12 +114,12 @@
 			<xs:element name="apromoreManagerPath" 	type="xs:string" 	minOccurs="0" 		maxOccurs="1"/>
 			<xs:element name="apromoreUserName" 	type="xs:string" 	minOccurs="0" 		maxOccurs="1"/>
 			<xs:element name="apromorePassword" 	type="xs:string" 	minOccurs="0" 		maxOccurs="1"/>
-			<xs:element name="apromoreUseProxy" 	type="xs:boolean" 	minOccurs="0" 		maxOccurs="1"/>			
+			<xs:element name="apromoreUseProxy" 	type="xs:boolean" 	minOccurs="0" 		maxOccurs="1"/>
 			<xs:element name="apromoreProxyName" 	type="xs:string" 	minOccurs="0" 		maxOccurs="1"/>
 			<xs:element name="apromoreProxyPort" 	type="xs:int" 		minOccurs="0" 		maxOccurs="1"/>
 		</xs:sequence>
 	</xs:complexType>
-	
+
 	<xs:complexType name="Process2Text">
 		<xs:sequence>
 			<xs:element name="p2tUse" type="xs:boolean" minOccurs="0" />
@@ -139,8 +142,8 @@
 			<xs:element name="serverport" type="xs:int" default="2711" minOccurs="0" />
 			<xs:element name="maxvalues" type="xs:int" default="1000" minOccurs="0" />
 		</xs:sequence>
-	</xs:complexType>	
-	
+	</xs:complexType>
+
 	<xs:complexType name="Woflan">
 		<xs:sequence>
 			<xs:element name="useWoflan" type="xs:boolean" default="false" minOccurs="0"/>
@@ -202,6 +205,6 @@
 			<xs:element name="launchCounter" type="xs:int" 		default="0" 	minOccurs="0" maxOccurs="1"/>
 			<xs:element name="showOnStartup" type="xs:boolean" 	default="true"  minOccurs="0" maxOccurs="1"/>
 			<xs:element name="registered" 	 type="xs:boolean" 	default="false" minOccurs="0" maxOccurs="1"/>
-	</xs:sequence>
+		</xs:sequence>
 	</xs:complexType>
 </xs:schema>

--- a/WoPeD-Configuration/src/main/java/org/woped/config/general/WoPeDGeneralConfiguration.java
+++ b/WoPeD-Configuration/src/main/java/org/woped/config/general/WoPeDGeneralConfiguration.java
@@ -28,7 +28,7 @@ import org.woped.core.utilities.LoggerManager;
 /**
  * Class that provides access to the general WoPeD configuration settings.
  * Access to it at runtime is to be gained through ConfigurationManager.
- * 
+ *
  * @see ConfigurationManager
  * @author Philip Allgaier
  *
@@ -66,7 +66,7 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 				return false;
 
 			isLoaded = true;
-				
+
 			// <business dashboard> tag is not existing yet -> create it
 			if (getConfDocument().getConfiguration().getBusinessdashboard() == null)
 				getConfDocument().getConfiguration().addNewBusinessdashboard();
@@ -98,7 +98,7 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 
 	/**
 	 * TODO: DOCUMENTATION (silenco)
-	 * 
+	 *
 	 * @return indicates whether loading was successful
 	 */
 	public boolean readConfig() {
@@ -167,7 +167,7 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 
 	/**
 	 * TODO: DOCUMENTATION (silenco)
-	 * 
+	 *
 	 * @param file
 	 * @return
 	 */
@@ -198,7 +198,7 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 
 	/**
 	 * TODO: DOCUMENTATION (silenco)
-	 * 
+	 *
 	 * @param configDoc
 	 * @return
 	 */
@@ -241,7 +241,7 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 				setHomedir(config.getGeneral().getHomedir());
 			else
 				setHomedir(getDefaultHomedir());
-			
+
 			LoggerManager.info(Constants.CONFIG_LOGGER,
 					rb.getString("Init.Config.SettingHomeDir") + ": " + getHomedir());
 
@@ -261,6 +261,11 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 			// TPN Export
 			setTpnSaveElementAsName(config.getTools().getExporting()
 					.getTpnExportElementAsName());
+
+			// YAWL Export
+
+			setYAWLExportExplicitPlaces(config.getTools().getExporting().getYawlExportExplicitPlaces());
+			setYAWLExportGroups(config.getTools().getExporting().getYawlExportGroups());
 
 			// Tools
 			setUseWoflan(config.getTools().getWoflan().getUseWoflan());
@@ -288,7 +293,7 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 
 	/**
 	 * TODO: DOCUMENTATION (silenco)
-	 * 
+	 *
 	 * @param file
 	 * @return
 	 */
@@ -333,7 +338,7 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 
 	/**
 	 * Returns the editingOnCreation.
-	 * 
+	 *
 	 * @return boolean
 	 */
 	public boolean isEditingOnCreation() {
@@ -343,7 +348,7 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 
 	/**
 	 * Sets the editingOnCreation.
-	 * 
+	 *
 	 * @param editingOnCreation
 	 *            The editingOnCreation to set
 	 */
@@ -357,7 +362,7 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 
 	/**
 	 * Returns the insertCOPYwhencopied.
-	 * 
+	 *
 	 * @return boolean
 	 */
 	public boolean isInsertCOPYwhenCopied() {
@@ -377,7 +382,7 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 
 	/**
 	 * Returns the exportToolspecific.
-	 * 
+	 *
 	 * @return boolean
 	 */
 	public boolean isExportToolspecific() {
@@ -387,7 +392,7 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 
 	/**
 	 * Returns the importToolspecific.
-	 * 
+	 *
 	 * @return boolean
 	 */
 	public boolean isImportToolspecific() {
@@ -397,7 +402,7 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 
 	/**
 	 * Sets the exportToolspecific.
-	 * 
+	 *
 	 * @param exportToolspecific
 	 *            The exportToolspecific to set
 	 */
@@ -408,7 +413,7 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 
 	/**
 	 * Sets the importToolspecific.
-	 * 
+	 *
 	 * @param importToolspecific
 	 *            The importToolspecific to set
 	 */
@@ -419,7 +424,7 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 
 	/**
 	 * Returns the recentFiles.
-	 * 
+	 *
 	 * @return Vector
 	 */
 	public Vector<WoPeDRecentFile> getRecentFiles() {
@@ -428,7 +433,7 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 
 	/**
 	 * TODO: optimize?
-	 * 
+	 *
 	 * @param name
 	 * @param path
 	 */
@@ -458,7 +463,7 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 
 	/**
 	 * Sets the recentFiles.
-	 * 
+	 *
 	 * @param path
 	 * @param name
 	 *            The recentFiles to set / public void setRecentFiles(Vector
@@ -483,7 +488,7 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 
 	/**
 	 * Returns if window is to be maximized on start-up.
-	 * 
+	 *
 	 * @return Dimension
 	 */
 	public boolean isMaximizeWindow() {
@@ -493,7 +498,7 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 
 	/**
 	 * Returns the windowSize.
-	 * 
+	 *
 	 * @return Dimension
 	 */
 	public Dimension getWindowSize() {
@@ -504,7 +509,7 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 
 	/**
 	 * Returns the windowX.
-	 * 
+	 *
 	 * @return int
 	 */
 	public int getWindowX() {
@@ -513,7 +518,7 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 
 	/**
 	 * Returns the windowY.
-	 * 
+	 *
 	 * @return int
 	 */
 	public int getWindowY() {
@@ -522,7 +527,7 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 
 	/**
 	 * Sets the windowSize.
-	 * 
+	 *
 	 * @param windowSize
 	 *            The windowSize to set
 	 */
@@ -540,7 +545,7 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 
 	/**
 	 * Sets the windowX.
-	 * 
+	 *
 	 * @param windowX
 	 *            The windowX to set
 	 */
@@ -550,7 +555,7 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 
 	/**
 	 * Sets the windowY.
-	 * 
+	 *
 	 * @param windowY
 	 *            The windowY to set
 	 */
@@ -560,7 +565,7 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 
 	/**
 	 * Sets the logdir.
-	 * 
+	 *
 	 * @param logdir
 	 *            The logdir to set
 	 */
@@ -574,7 +579,7 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 
 	/**
 	 * Returns the home directory.
-	 * 
+	 *
 	 * @return String
 	 */
 	public String getHomedir() {
@@ -590,7 +595,7 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 
 	/**
 	 * Sets the home directory.
-	 * 
+	 *
 	 * @param hd
 	 *            The home directory to set
 	 */
@@ -600,7 +605,7 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 
 	/**
 	 * Returns the useWoflan.
-	 * 
+	 *
 	 * @return boolean
 	 */
 	public boolean isUseWoflan() {
@@ -610,7 +615,7 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 
 	/**
 	 * Returns the woflanPath.
-	 * 
+	 *
 	 * @return String
 	 */
 	public String getWoflanPath() {
@@ -620,7 +625,7 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 
 	/**
 	 * Sets the useWoflan.
-	 * 
+	 *
 	 * @param useWoflan
 	 *            The useWoflan to set
 	 */
@@ -631,7 +636,7 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 
 	/**
 	 * Sets the woflanPath.
-	 * 
+	 *
 	 * @param woflanPath
 	 *            The woflanPath to set
 	 */
@@ -642,7 +647,7 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 
 	/**
 	 * Returns the smartEditing.
-	 * 
+	 *
 	 * @return boolean
 	 */
 	public boolean isSmartEditing() {
@@ -652,7 +657,7 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 
 	/**
 	 * Sets the smartEditing.
-	 * 
+	 *
 	 * @param smartEditing
 	 *            The smartEditing to set
 	 */
@@ -758,7 +763,7 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.woped.editor.config.IConfiguration#getPortColor()
 	 */
 	public Color getPortColor() {
@@ -767,7 +772,7 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.woped.editor.config.IConfiguration#setPortColor(java.awt.Color)
 	 */
 	public void setPortColor(Color color) {
@@ -776,7 +781,7 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see
 	 * org.woped.editor.config.IConfiguration#setLocaleLanguage(java.lang.String
 	 * )
@@ -788,7 +793,7 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.woped.editor.config.IConfiguration#getLocaleLanguage()
 	 */
 	public String getLocaleLanguage() {
@@ -802,7 +807,7 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see
 	 * org.woped.editor.config.IConfiguration#setLocaleCountry(java.lang.String)
 	 */
@@ -813,7 +818,7 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.woped.editor.config.IConfiguration#getLocaleCountry()
 	 */
 	public String getLocaleCountry() {
@@ -827,7 +832,7 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see
 	 * org.woped.editor.config.IConfiguration#setLocaleVariant(java.lang.String)
 	 */
@@ -838,7 +843,7 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.woped.editor.config.IConfiguration#getLocaleVariant()
 	 */
 	public String getLocaleVariant() {
@@ -1469,8 +1474,8 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 
 	@Override
 	public void addApromoreServer(int ID, String name, String url, int port,
-			String path, String user, String pwd, boolean useProxy,
-			String proxyUrl, int proxyPort) {
+								  String path, String user, String pwd, boolean useProxy,
+								  String proxyUrl, int proxyPort) {
 		if (isSetApromoreServers()) {
 			setServerAttribute(ID, name, url, port, path, user, pwd, useProxy,
 					proxyUrl, proxyPort);
@@ -1482,8 +1487,8 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 	}
 
 	private void setServerAttribute(int ID, String name, String url, int port,
-			String path, String user, String pwd, boolean useProxy,
-			String proxyUrl, int proxyPort) {
+									String path, String user, String pwd, boolean useProxy,
+									String proxyUrl, int proxyPort) {
 		getConfDocument().getConfiguration().getApromoreServers()
 				.addNewApromoreServer();
 		int i = getApromoreServerListLength();
@@ -1508,8 +1513,8 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 
 	@Override
 	public void changeApromoreServerSettings(int ID, String name, String url,
-			int port, String path, String user, String pwd, boolean useProxy,
-			String proxyUrl, int proxyPort) {
+											 int port, String path, String user, String pwd, boolean useProxy,
+											 String proxyUrl, int proxyPort) {
 		ApromoreServer[] servers = getApromoreServers();
 		for (ApromoreServer server : servers) {
 			if (server.getApromoreServerID() == ID) {
@@ -1654,9 +1659,9 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 
 	@Override
 	public int getBusinessDashboardServerPort() {
-		
+
 		BusinessDashboard bd = getConfDocument().getConfiguration().getBusinessdashboard();
-		
+
 		if (bd.isSetServerport()) {
 			return getConfDocument().getConfiguration().getBusinessdashboard()
 					.getServerport();
@@ -1667,15 +1672,15 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 
 	@Override
 	public void setBusinessDashboardServerPort(int port) {
-		
+
 		getConfDocument().getConfiguration().getBusinessdashboard().setServerport(port);
-		
+
 	}
 
 	@Override
 	public boolean getBusinessDashboardUseByDefault() {
 		BusinessDashboard bd = getConfDocument().getConfiguration().getBusinessdashboard();
-		
+
 		if (bd.isSetUsebydefault()) {
 			return getConfDocument().getConfiguration().getBusinessdashboard()
 					.getUsebydefault();
@@ -1687,13 +1692,13 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 	@Override
 	public void setBusinessDashboardUseByDefault(boolean bAutoStart) {
 		getConfDocument().getConfiguration().getBusinessdashboard().setUsebydefault(bAutoStart);
-		
+
 	}
 
 	@Override
 	public int getBusinessDashboardMaxValues() {
 		BusinessDashboard bd = getConfDocument().getConfiguration().getBusinessdashboard();
-		
+
 		if (bd.isSetMaxvalues()) {
 			return getConfDocument().getConfiguration().getBusinessdashboard()
 					.getMaxvalues();
@@ -1705,6 +1710,65 @@ public class WoPeDGeneralConfiguration extends WoPeDConfiguration implements
 	@Override
 	public void setBusinessDashboardMaxValues(int maxvalues) {
 		getConfDocument().getConfiguration().getBusinessdashboard().setMaxvalues(maxvalues);
-		
+
+	}
+
+	// YAWL
+
+	/**
+	 * Returns the yawlEnabled
+	 *
+	 * @return boolean
+	 */
+	public boolean isYAWLEnabled() {
+		return getConfDocument().getConfiguration().getTools().getYawlEnabled();
+	}
+
+	/**
+	 * Sets the yawlEnabled
+	 *
+	 * @return boolean
+	 */
+	public void setYAWLEnabled(boolean yawlEnabled) {
+		getConfDocument().getConfiguration().getTools().setYawlEnabled(yawlEnabled);
+	}
+
+	/**
+	 * Returns the exportExplicitPlaces
+	 *
+	 * @return boolean
+	 */
+	public boolean isYAWLExportExplicitPlaces() {
+		return getConfDocument().getConfiguration().getTools().getExporting()
+				.getYawlExportExplicitPlaces();
+	}
+
+	/**
+	 * Sets the exportExplicitPlaces
+	 *
+	 * @param exportExplicitPlaces
+	 *            The exportToolspecific to set
+	 */
+	public void setYAWLExportExplicitPlaces(boolean exportExplicitPlaces) {
+		getConfDocument().getConfiguration().getTools().getExporting()
+				.setYawlExportExplicitPlaces(exportExplicitPlaces);
+	}
+
+	/**
+	 * Returns the exportGroups
+	 *
+	 * @return boolean
+	 */
+	public boolean isYAWLExportGroups() {
+		return getConfDocument().getConfiguration().getTools().getExporting().getYawlExportGroups();
+	}
+
+	/**
+	 * Sets the exportGroups
+	 *
+	 * @param exportGroups
+	 */
+	public void setYAWLExportGroups(boolean exportGroups) {
+		getConfDocument().getConfiguration().getTools().getExporting().setYawlExportGroups(exportGroups);
 	}
 }

--- a/WoPeD-Core/src/main/java/org/woped/core/config/DefaultStaticConfiguration.java
+++ b/WoPeD-Core/src/main/java/org/woped/core/config/DefaultStaticConfiguration.java
@@ -12,7 +12,7 @@ import org.woped.config.ApromoreServer;
 /**
  * Class that provides fallback configuration settings for the general WoPeD
  * configuration part
- * 
+ *
  * @author Philip Allgaier
  *
  */
@@ -96,13 +96,13 @@ public class DefaultStaticConfiguration implements IGeneralConfiguration {
 	public static int DEFAULT_BUSINESSDASHBOARD_PORT = 2711;
 	public static int DEFAULT_BUSINESSDASHBOARD_MAXVALUES = 1000;
 	public static boolean DEFAULT_BUSINESSDASHBOARD_USEBYDEFAULT = false;
-    // Booleans for alpha-functions (TEST) later integration in configuration &
-    // GUI
-    public static boolean ACTIVATE_NET_ROUTING = false;
-    public static boolean ACTIVATE_ANNEALING_LAYOUT = false;
-    // Language
-    public Locale locale = Locale.getDefault();
-    // File
+	// Booleans for alpha-functions (TEST) later integration in configuration &
+	// GUI
+	public static boolean ACTIVATE_NET_ROUTING = false;
+	public static boolean ACTIVATE_ANNEALING_LAYOUT = false;
+	// Language
+	public Locale locale = Locale.getDefault();
+	// File
 	private String homedir = "";
 	private String logdir = "";
 	private String defaultHomedir = "";
@@ -143,17 +143,17 @@ public class DefaultStaticConfiguration implements IGeneralConfiguration {
 	// P2T
 	private String process2text_serverHost = DEFAULT_PROCESS2TEXT_HOST;
 	private int process2text_serverPort = DEFAULT_PROCESS2TEXT_PORT;
-    private String process2text_serverUri = DEFAULT_PROCESS2TEXT_URI;
-    private boolean process2text_use = DEFAULT_PROCESS2TEXT_USE;
+	private String process2text_serverUri = DEFAULT_PROCESS2TEXT_URI;
+	private boolean process2text_use = DEFAULT_PROCESS2TEXT_USE;
 
 	// T2P
 	private String text2process_serverHost = DEFAULT_TEXT2PROCESS_HOST;
 	private int text2process_serverPort = DEFAULT_TEXT2PROCESS_PORT;
-    private String text2process_serverUri = DEFAULT_TEXT2PROCESS_URI;
-    private boolean text2process_use = DEFAULT_TEXT2PROCESS_USE;
+	private String text2process_serverUri = DEFAULT_TEXT2PROCESS_URI;
+	private boolean text2process_use = DEFAULT_TEXT2PROCESS_USE;
 
 	//Dashboard
-    private int businessdashboard_serverport = DEFAULT_BUSINESSDASHBOARD_PORT;
+	private int businessdashboard_serverport = DEFAULT_BUSINESSDASHBOARD_PORT;
 	private int businessdashboard_maxvalues = DEFAULT_BUSINESSDASHBOARD_MAXVALUES;
 	private boolean businessdashboard_usebydefault = DEFAULT_BUSINESSDASHBOARD_USEBYDEFAULT;
 	// Understandability Coloring
@@ -198,6 +198,13 @@ public class DefaultStaticConfiguration implements IGeneralConfiguration {
 	private String registrationEmail;
 	private int launchCounter;
 
+	// YAWL
+	private boolean yawlEnabled = false;
+
+	private boolean yawlExportExplicitPlaces = false;
+
+	private boolean yawlExportGroups = false;
+
 	public DefaultStaticConfiguration() {
 		initConfig();
 	}
@@ -226,17 +233,17 @@ public class DefaultStaticConfiguration implements IGeneralConfiguration {
 		return headsize;
 	}
 
-    public void setArrowheadSize(int headSize) {
-        this.headsize = headSize;
-    }
+	public void setArrowheadSize(int headSize) {
+		this.headsize = headSize;
+	}
 
 	public int getArrowWidth() {
 		return arrowwidth;
 	}
 
-    public void setArrowWidth(int width) {
-        this.arrowwidth = width;
-    }
+	public void setArrowWidth(int width) {
+		this.arrowwidth = width;
+	}
 
 	public Color getSelectionColor() {
 		return selectionColor;
@@ -250,33 +257,33 @@ public class DefaultStaticConfiguration implements IGeneralConfiguration {
 		return homedir;
 	}
 
-    public void setHomedir(String homedir) {
-        this.homedir = homedir;
-    }
+	public void setHomedir(String homedir) {
+		this.homedir = homedir;
+	}
 
 	public String getDefaultHomedir() {
 		return defaultHomedir;
 	}
 
-    public void setDefaultHomedir(String homedir) {
-        this.defaultHomedir = homedir;
-    }
+	public void setDefaultHomedir(String homedir) {
+		this.defaultHomedir = homedir;
+	}
 
 	public String getCurrentWorkingdir() {
 		return currentWorkingdir;
 	}
 
-    public void setCurrentWorkingdir(String homedir) {
-        this.defaultHomedir = homedir;
-    }
+	public void setCurrentWorkingdir(String homedir) {
+		this.defaultHomedir = homedir;
+	}
 
 	public String getLogdir() {
 		return logdir;
 	}
 
-    public void setLogdir(String logdir) {
-        this.logdir = logdir;
-    }
+	public void setLogdir(String logdir) {
+		this.logdir = logdir;
+	}
 
 	// Start Understandability Coloring
 	public boolean getColorOn() {
@@ -291,129 +298,129 @@ public class DefaultStaticConfiguration implements IGeneralConfiguration {
 		return color1;
 	}
 
-    public void setColor1(int rgb) {
-        color1 = rgb;
-    }
+	public void setColor1(int rgb) {
+		color1 = rgb;
+	}
 
 	public int getColor2() {
 		return color2;
 	}
 
-    public void setColor2(int rgb) {
-        color2 = rgb;
-    }
+	public void setColor2(int rgb) {
+		color2 = rgb;
+	}
 
 	public int getColor3() {
 		return color3;
 	}
 
-    public void setColor3(int rgb) {
-        color3 = rgb;
-    }
+	public void setColor3(int rgb) {
+		color3 = rgb;
+	}
 
 	public int getColor4() {
 		return color4;
 	}
 
-    public void setColor4(int rgb) {
-        color4 = rgb;
-    }
+	public void setColor4(int rgb) {
+		color4 = rgb;
+	}
 
 	public int getColor5() {
 		return color5;
 	}
 
-    public void setColor5(int rgb) {
-        color5 = rgb;
-    }
+	public void setColor5(int rgb) {
+		color5 = rgb;
+	}
 
 	public int getColor6() {
 		return color6;
 	}
 
-    public void setColor6(int rgb) {
-        color6 = rgb;
-    }
+	public void setColor6(int rgb) {
+		color6 = rgb;
+	}
 
 	public int getColor7() {
 		return color7;
 	}
 
-    public void setColor7(int rgb) {
-        color7 = rgb;
-    }
+	public void setColor7(int rgb) {
+		color7 = rgb;
+	}
 
 	public int getColor8() {
 		return color8;
 	}
 
-    public void setColor8(int rgb) {
-        color8 = rgb;
-    }
+	public void setColor8(int rgb) {
+		color8 = rgb;
+	}
 
 	public int getColor9() {
 		return color9;
 	}
 
-    public void setColor9(int rgb) {
-        color9 = rgb;
-    }
+	public void setColor9(int rgb) {
+		color9 = rgb;
+	}
 
 	public int getColor10() {
 		return color10;
 	}
 
-    public void setColor10(int rgb) {
-        color10 = rgb;
-    }
+	public void setColor10(int rgb) {
+		color10 = rgb;
+	}
 
 	public int getColor11() {
 		return color11;
 	}
 
-    public void setColor11(int rgb) {
-        color11 = rgb;
-    }
+	public void setColor11(int rgb) {
+		color11 = rgb;
+	}
 
 	public int getColor12() {
 		return color12;
 	}
 
-    public void setColor12(int rgb) {
-        color12 = rgb;
-    }
+	public void setColor12(int rgb) {
+		color12 = rgb;
+	}
 
 	public int getColor13() {
 		return color13;
 	}
 
-    public void setColor13(int rgb) {
-        color13 = rgb;
-    }
+	public void setColor13(int rgb) {
+		color13 = rgb;
+	}
 
 	public int getColor14() {
 		return color14;
 	}
 
-    public void setColor14(int rgb) {
-        color14 = rgb;
-    }
+	public void setColor14(int rgb) {
+		color14 = rgb;
+	}
 
 	public int getColor15() {
 		return color15;
 	}
 
-    public void setColor15(int rgb) {
-        color15 = rgb;
-    }
+	public void setColor15(int rgb) {
+		color15 = rgb;
+	}
 
 	public int getColor16() {
 		return color16;
 	}
 
-    public void setColor16(int rgb) {
-        color16 = rgb;
-    }
+	public void setColor16(int rgb) {
+		color16 = rgb;
+	}
 
 	public Color[] getUnderstandColors() {
 		return UnderstandColorArray;
@@ -471,7 +478,7 @@ public class DefaultStaticConfiguration implements IGeneralConfiguration {
 		return defaultcolor13;
 	}
 
-    // End Understandability Coloring
+	// End Understandability Coloring
 
 	public int getDefaultColor14() {
 		return defaultcolor14;
@@ -501,9 +508,9 @@ public class DefaultStaticConfiguration implements IGeneralConfiguration {
 		return lnf;
 	}
 
-    public void setLookAndFeel(String className) {
-        lnf = className;
-    }
+	public void setLookAndFeel(String className) {
+		lnf = className;
+	}
 
 	public Vector<?> getRecentFiles() {
 		return new Vector<Object>();
@@ -513,60 +520,60 @@ public class DefaultStaticConfiguration implements IGeneralConfiguration {
 		return new Dimension(800, 600);
 	}
 
-    public void setWindowSize(Dimension windowSize) {
-    }
+	public void setWindowSize(Dimension windowSize) {
+	}
 
 	public boolean isMaximizeWindow() {
 		return true;
 	}
 
-    public void setMaximizeWindow(boolean maximize) {
-    }
+	public void setMaximizeWindow(boolean maximize) {
+	}
 
 	public int getWindowX() {
 		return 0;
 	}
 
-    public void setWindowX(int windowX) {
-    }
+	public void setWindowX(int windowX) {
+	}
 
 	public int getWindowY() {
 		return 0;
 	}
 
-    public void setWindowY(int windowY) {
-    }
+	public void setWindowY(int windowY) {
+	}
 
 	public String getWoflanPath() {
 		return "";
 	}
 
-    public void setWoflanPath(String woflanPath) {
-    }
+	public void setWoflanPath(String woflanPath) {
+	}
 
 	public boolean isEditingOnCreation() {
 		return editoncreation;
 	}
 
-    public void setEditingOnCreation(boolean editingOnCreation) {
-        this.editoncreation = editingOnCreation;
-    }
+	public void setEditingOnCreation(boolean editingOnCreation) {
+		this.editoncreation = editingOnCreation;
+	}
 
 	public boolean isExportToolspecific() {
 		return exportToolspec;
 	}
 
-    public void setExportToolspecific(boolean exportToolspecific) {
-        this.exportToolspec = exportToolspecific;
-    }
+	public void setExportToolspecific(boolean exportToolspecific) {
+		this.exportToolspec = exportToolspecific;
+	}
 
 	public boolean isFillArrowHead() {
 		return fillArrow;
 	}
 
-    public void setFillArrowHead(boolean fill) {
-        this.fillArrow = fill;
-    }
+	public void setFillArrowHead(boolean fill) {
+		this.fillArrow = fill;
+	}
 
 	public boolean isHomedirSet() {
 		return getHomedir() != null && !getHomedir().equals("");
@@ -585,75 +592,75 @@ public class DefaultStaticConfiguration implements IGeneralConfiguration {
 		return importToolspec;
 	}
 
-    public void setImportToolspecific(boolean importToolspecific) {
-        this.importToolspec = importToolspecific;
-    }
+	public void setImportToolspecific(boolean importToolspecific) {
+		this.importToolspec = importToolspecific;
+	}
 
 	public boolean isInsertCOPYwhenCopied() {
 		return insertCopy;
 	}
 
-    public void setInsertCOPYwhenCopied(boolean insertCOPYwhenCopied) {
-        insertCopy = insertCOPYwhenCopied;
-    }
+	public void setInsertCOPYwhenCopied(boolean insertCOPYwhenCopied) {
+		insertCopy = insertCOPYwhenCopied;
+	}
 
 	public boolean isRoundRouting() {
 		return roundRouting;
 	}
 
-    public void setRoundRouting(boolean round) {
-        this.roundRouting = round;
-    }
+	public void setRoundRouting(boolean round) {
+		this.roundRouting = round;
+	}
 
 	public boolean isShowGrid() {
 		return showgrid;
 	}
 
-    public void setShowGrid(boolean showGrid) {
-        this.showgrid = showGrid;
-    }
+	public void setShowGrid(boolean showGrid) {
+		this.showgrid = showGrid;
+	}
 
 	public boolean isSmartEditing() {
 		return smartediting;
 	}
 
-    public void setSmartEditing(boolean smartEditing) {
-        this.smartediting = smartEditing;
-    }
+	public void setSmartEditing(boolean smartEditing) {
+		this.smartediting = smartEditing;
+	}
 
 	public boolean isTpnSaveElementAsName() {
 		return false;
 	}
 
-    public void setTpnSaveElementAsName(boolean b) {
-    }
-
-    public boolean isUseWoflan() {
-        return false;
+	public void setTpnSaveElementAsName(boolean b) {
 	}
 
-    public void setUseWoflan(boolean useWoflan) {
-    }
+	public boolean isUseWoflan() {
+		return false;
+	}
 
-    public boolean isUseWoflanDLL() {
-        return false;
-    }
+	public void setUseWoflan(boolean useWoflan) {
+	}
 
-    public void setUseWoflanDLL(boolean useWoflanDLL) {
-    }
+	public boolean isUseWoflanDLL() {
+		return false;
+	}
 
-    public void removeAllRecentFiles() {
-    }
+	public void setUseWoflanDLL(boolean useWoflanDLL) {
+	}
 
-    public void removeRecentFile(String name, String path) {
-    }
+	public void removeAllRecentFiles() {
+	}
+
+	public void removeRecentFile(String name, String path) {
+	}
 
 	public String getUserdir() {
 		return this.userdir;
 	}
 
 	/**
-	 * 
+	 *
 	 * @see org.woped.config.IGeneralConfiguration#getPortColor()
 	 */
 	public Color getPortColor() {
@@ -661,7 +668,7 @@ public class DefaultStaticConfiguration implements IGeneralConfiguration {
 	}
 
 	/**
-	 * 
+	 *
 	 * @see org.woped.config.IGeneralConfiguration#setPortColor(java.awt.Color)
 	 */
 	public void setPortColor(Color color) {
@@ -669,7 +676,7 @@ public class DefaultStaticConfiguration implements IGeneralConfiguration {
 	}
 
 	/**
-	 * 
+	 *
 	 * @see org.woped.config.IGeneralConfiguration#getLocaleLanguage()
 	 */
 	public String getLocaleLanguage() {
@@ -677,7 +684,7 @@ public class DefaultStaticConfiguration implements IGeneralConfiguration {
 	}
 
 	/**
-	 * 
+	 *
 	 * @see org.woped.config.IGeneralConfiguration#setLocaleLanguage(java.lang.String)
 	 */
 	public void setLocaleLanguage(String language) {
@@ -685,7 +692,7 @@ public class DefaultStaticConfiguration implements IGeneralConfiguration {
 	}
 
 	/**
-	 * 
+	 *
 	 * @see org.woped.config.IGeneralConfiguration#getLocaleCountry()
 	 */
 	public String getLocaleCountry() {
@@ -693,7 +700,7 @@ public class DefaultStaticConfiguration implements IGeneralConfiguration {
 	}
 
 	/**
-	 * 
+	 *
 	 * @see org.woped.config.IGeneralConfiguration#setLocaleCountry(java.lang.String)
 	 */
 	public void setLocaleCountry(String country) {
@@ -701,7 +708,7 @@ public class DefaultStaticConfiguration implements IGeneralConfiguration {
 	}
 
 	/**
-	 * 
+	 *
 	 * @see org.woped.config.IGeneralConfiguration#getLocaleVariant()
 	 */
 	public String getLocaleVariant() {
@@ -709,7 +716,7 @@ public class DefaultStaticConfiguration implements IGeneralConfiguration {
 	}
 
 	/**
-	 * 
+	 *
 	 * @see org.woped.config.IGeneralConfiguration#setLocaleVariant(java.lang.String)
 	 */
 	public void setLocaleVariant(String variant) {
@@ -738,8 +745,8 @@ public class DefaultStaticConfiguration implements IGeneralConfiguration {
 		return 2;
 	}
 
-    public void setAlgorithmDecimalPlaces(int n) {
-    }
+	public void setAlgorithmDecimalPlaces(int n) {
+	}
 
 	public int getVariableDecimalPlaces() {
 		return 0;
@@ -778,7 +785,7 @@ public class DefaultStaticConfiguration implements IGeneralConfiguration {
 	public void setCurrentApromoreIndex(int index) {
 		this.apromore_currentIndex = index;
 	}
-	
+
 	@Override
 	public boolean isSetApromorePassword() {
 		return apromore_isSetPassword;
@@ -797,14 +804,14 @@ public class DefaultStaticConfiguration implements IGeneralConfiguration {
 	}
 
 	@Override
-    public String getApromoreUsername() {
+	public String getApromoreUsername() {
 
-        return apromore_username;
-    }
+		return apromore_username;
+	}
 
 	@Override
-    public void setApromoreUsername(String user) {
-        this.apromore_username = user;
+	public void setApromoreUsername(String user) {
+		this.apromore_username = user;
 
 	}
 
@@ -839,12 +846,12 @@ public class DefaultStaticConfiguration implements IGeneralConfiguration {
 	}
 
 	@Override
-    public void setApromoreServerPort(int port) {
-        apromore_serverport = port;
-    }
+	public void setApromoreServerPort(int port) {
+		apromore_serverport = port;
+	}
 
-    @Override
-    public boolean getApromoreUseProxy() {
+	@Override
+	public boolean getApromoreUseProxy() {
 
 		return apromore_useproxy;
 	}
@@ -856,14 +863,14 @@ public class DefaultStaticConfiguration implements IGeneralConfiguration {
 	}
 
 	@Override
-    public boolean getApromoreUse() {
-        return apromore_use;
-    }
+	public boolean getApromoreUse() {
+		return apromore_use;
+	}
 
 	@Override
-    public void setApromoreUse(boolean selected) {
-        apromore_use = selected;
-    }
+	public void setApromoreUse(boolean selected) {
+		apromore_use = selected;
+	}
 
 	@Override
 	public boolean isRegistered() {
@@ -960,15 +967,15 @@ public class DefaultStaticConfiguration implements IGeneralConfiguration {
 
 	@Override
 	public void addApromoreServer(int ID, String name, String url, int port,
-			String path, String user, String pwd, boolean useProxy,
-			String proxyUrl, int proxyPort) {
+								  String path, String user, String pwd, boolean useProxy,
+								  String proxyUrl, int proxyPort) {
 
 	}
 
 	@Override
 	public void changeApromoreServerSettings(int ID, String name, String url,
-			int port, String path, String user, String pwd, boolean useProxy,
-			String proxyUrl, int proxyPort) {
+											 int port, String path, String user, String pwd, boolean useProxy,
+											 String proxyUrl, int proxyPort) {
 
 	}
 
@@ -1017,7 +1024,7 @@ public class DefaultStaticConfiguration implements IGeneralConfiguration {
 		this.process2text_use = selected;
 	}
 
-// Text 2 Process
+	// Text 2 Process
 	@Override
 	public String getText2ProcessServerHost() {
 		return text2process_serverHost;
@@ -1059,7 +1066,7 @@ public class DefaultStaticConfiguration implements IGeneralConfiguration {
 	}
 
 
-	
+
 	@Override
 	public int getBusinessDashboardServerPort() {
 		return this.businessdashboard_serverport;
@@ -1068,7 +1075,7 @@ public class DefaultStaticConfiguration implements IGeneralConfiguration {
 	@Override
 	public void setBusinessDashboardServerPort(int port) {
 		this.businessdashboard_serverport = port;
-		
+
 	}
 
 	@Override
@@ -1078,7 +1085,7 @@ public class DefaultStaticConfiguration implements IGeneralConfiguration {
 
 	@Override
 	public void setBusinessDashboardUseByDefault(boolean bAutoStart) {
-		this.businessdashboard_usebydefault = bAutoStart;	
+		this.businessdashboard_usebydefault = bAutoStart;
 	}
 
 	@Override
@@ -1089,9 +1096,29 @@ public class DefaultStaticConfiguration implements IGeneralConfiguration {
 	@Override
 	public void setBusinessDashboardMaxValues(int maxvalues) {
 		this.businessdashboard_maxvalues = maxvalues;
-		
+
 	}
 
+	// YAWL
 
+	public boolean isYAWLEnabled() {
+		return yawlEnabled;
+	}
+
+	public void setYAWLEnabled(boolean yawlEnabled) {
+		this.yawlEnabled = yawlEnabled;
+	}
+
+	public boolean isYAWLExportExplicitPlaces() { return yawlExportExplicitPlaces; }
+
+	public void setYAWLExportExplicitPlaces(boolean yawlExportExplicitPlaces) {
+		this.yawlExportExplicitPlaces = yawlExportExplicitPlaces;
+	}
+
+	public boolean isYAWLExportGroups() { return yawlExportGroups; }
+
+	public void setYAWLExportGroups(boolean exportGroups) {
+		this.yawlExportGroups = exportGroups;
+	}
 
 }

--- a/WoPeD-Core/src/main/java/org/woped/core/config/IGeneralConfiguration.java
+++ b/WoPeD-Core/src/main/java/org/woped/core/config/IGeneralConfiguration.java
@@ -9,7 +9,7 @@ import org.woped.config.ApromoreServer;
 
 /**
  * Interface defining the public capabilities of the general WoPeD configuration
- * 
+ *
  * @author Philip Allgaier
  *
  */
@@ -448,7 +448,7 @@ public interface IGeneralConfiguration extends IConfiguration {
 	public int getApromoreProxyPort();
 
 	public void setApromoreProxyPort(int port);
-	
+
 	public boolean isSetApromorePassword();
 
 	//
@@ -480,12 +480,12 @@ public interface IGeneralConfiguration extends IConfiguration {
 	public ApromoreServer[] getApromoreServers();
 
 	public void addApromoreServer(int ID, String name, String url, int port,
-			String path, String user, String pwd, boolean useProxy,
-			String proxyUrl, int proxyPort);
+								  String path, String user, String pwd, boolean useProxy,
+								  String proxyUrl, int proxyPort);
 
 	public void changeApromoreServerSettings(int ID, String name, String url,
-			int port, String path, String user, String pwd, boolean useProxy,
-			String proxyUrl, int proxyPort);
+											 int port, String path, String user, String pwd, boolean useProxy,
+											 String proxyUrl, int proxyPort);
 
 	public void removeApromoreServer(int index);
 
@@ -520,17 +520,30 @@ public interface IGeneralConfiguration extends IConfiguration {
 	public boolean getText2ProcessUse();
 
 	public void setText2ProcessUse(boolean selected);
-	
+
 	//dashboard
 	public int getBusinessDashboardServerPort();
 
 	public void setBusinessDashboardServerPort(int port);
-	
+
 	public boolean getBusinessDashboardUseByDefault();
 
 	public void setBusinessDashboardUseByDefault(boolean bAutoStart);
-	
+
 	public int getBusinessDashboardMaxValues();
 
 	public void setBusinessDashboardMaxValues(int maxvalues);
+
+	// YAWL
+	public boolean isYAWLEnabled();
+
+	public void setYAWLEnabled(boolean yawlEnabled);
+
+	public boolean isYAWLExportExplicitPlaces();
+
+	public void setYAWLExportExplicitPlaces(boolean exportExplicitPlaces);
+
+	public boolean isYAWLExportGroups();
+
+	public void setYAWLExportGroups(boolean exportGroups);
 }

--- a/WoPeD-Editor/src/main/java/org/woped/editor/controller/vc/ConfigVC.java
+++ b/WoPeD-Editor/src/main/java/org/woped/editor/controller/vc/ConfigVC.java
@@ -50,15 +50,7 @@ import org.woped.core.utilities.FileFilterImpl;
 import org.woped.core.utilities.Utils;
 import org.woped.editor.action.EditorViewEvent;
 import org.woped.editor.controller.ApplicationMediator;
-import org.woped.editor.gui.config.AbstractConfPanel;
-import org.woped.editor.gui.config.ConfApromorePanel;
-import org.woped.editor.gui.config.ConfBusinessDashboardPanel;
-import org.woped.editor.gui.config.ConfEditorPanel;
-import org.woped.editor.gui.config.ConfFilePanel;
-import org.woped.editor.gui.config.ConfLanguagePanel;
-import org.woped.editor.gui.config.ConfMetricsPanel;
-import org.woped.editor.gui.config.ConfNLPToolsPanel;
-import org.woped.editor.gui.config.ConfUnderstandabilityPanel;
+import org.woped.editor.gui.config.*;
 import org.woped.gui.lookAndFeel.WopedButton;
 import org.woped.gui.translations.Messages;
 
@@ -94,6 +86,7 @@ public class ConfigVC extends JDialog implements IViewController {
 	private AbstractConfPanel p2tPanel = null;
 	private AbstractConfPanel aproPanel = null;
 	private AbstractConfPanel businessdashboardPanel = null;
+	private AbstractConfPanel yawlPanel = null;
 	// ButtonPanel
 	private JPanel buttonPanel = null;
 	private WopedButton okButton = null;
@@ -200,7 +193,7 @@ public class ConfigVC extends JDialog implements IViewController {
 			if (((FileFilterImpl) jfc.getFileFilter()).getFilterType() == FileFilterImpl.XMLFilter) {
 				savePath = savePath
 						+ Utils.getQualifiedFileName(jfc.getSelectedFile()
-								.getName(), xmlExtensions);
+						.getName(), xmlExtensions);
 			}
 			ConfigurationManager.getConfiguration().saveConfig(
 					new File(savePath));
@@ -228,7 +221,7 @@ public class ConfigVC extends JDialog implements IViewController {
 			if (((FileFilterImpl) jfc.getFileFilter()).getFilterType() == FileFilterImpl.XMLFilter) {
 				readPath = readPath
 						+ Utils.getQualifiedFileName(jfc.getSelectedFile()
-								.getName(), xmlExtensions);
+						.getName(), xmlExtensions);
 			}
 			ConfigurationManager.getConfiguration().readConfig(
 					new File(readPath));
@@ -240,7 +233,7 @@ public class ConfigVC extends JDialog implements IViewController {
 	// ##################### Listener Methoden ############################# */
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see
 	 * javax.swing.event.TreeSelectionListener#valueChanged(javax.swing.event
 	 * .TreeSelectionEvent)
@@ -271,7 +264,7 @@ public class ConfigVC extends JDialog implements IViewController {
 			colorPanel = new ConfUnderstandabilityPanel(
 					Messages.getString("Configuration.ColorLayout.Title"));
 			tabbedPane.addTab(Messages
-					.getString("Configuration.ColorLayout.ColorPanel.Title"),
+							.getString("Configuration.ColorLayout.ColorPanel.Title"),
 					colorPanel);
 			confPanels.put(colorPanel.getPanelName(), colorPanel);
 			metricsPanel = new ConfMetricsPanel(
@@ -292,11 +285,15 @@ public class ConfigVC extends JDialog implements IViewController {
 			tabbedPane.addTab(Messages.getString("Configuration.P2T.Title"),
 					p2tPanel);
 			confPanels.put(p2tPanel.getPanelName(), p2tPanel);
-			
+
 			businessdashboardPanel = new ConfBusinessDashboardPanel("Business Dashboard");
 			tabbedPane.addTab("Business Dashboard", businessdashboardPanel);
 			confPanels.put(businessdashboardPanel.getPanelName(), businessdashboardPanel);
-			
+
+			yawlPanel = new ConfYAWLPanel(Messages.getString("Configuration.YAWL.Title"));
+			tabbedPane.addTab(Messages.getString("Configuration.YAWL.Title"), yawlPanel);
+			confPanels.put(yawlPanel.getPanelName(), yawlPanel);
+
 			readConfiguration();
 			/*
 			 * tabbedPane.addChangeListener(new ChangeListener() { public void
@@ -347,7 +344,7 @@ public class ConfigVC extends JDialog implements IViewController {
 			cancelButton.setIcon(Messages.getImageIcon("Button.Cancel"));
 			cancelButton.addActionListener(new ActionListener() {
 				public void actionPerformed(ActionEvent arg0) {
-					
+
 
 					int result = JOptionPane.showConfirmDialog(
 							tabbedPane,
@@ -360,8 +357,8 @@ public class ConfigVC extends JDialog implements IViewController {
 						aproPanel.setButtonsToDefault();
 						resetConfiguration();
 						ConfigVC.this.dispose();
-					} 
-					
+					}
+
 				}
 			});
 		}

--- a/WoPeD-Editor/src/main/java/org/woped/editor/gui/config/ConfYAWLPanel.java
+++ b/WoPeD-Editor/src/main/java/org/woped/editor/gui/config/ConfYAWLPanel.java
@@ -1,0 +1,211 @@
+/*
+ *
+ * Copyright (C) 2004-2005, see @author in JavaDoc for the author
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ *
+ * For contact information please visit http://woped.dhbw-karlsruhe.de
+ *
+ */
+package org.woped.editor.gui.config;
+
+import org.woped.core.config.ConfigurationManager;
+import org.woped.gui.translations.Messages;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+
+public class ConfYAWLPanel extends AbstractConfPanel {
+
+    // Panels
+    private JPanel YAWLEnabledPanel = null;
+    private JPanel YAWLOptionsPanel = null;
+
+    // Boxes
+    private JCheckBox yawlEnabledBox = null;
+    private JCheckBox yawlExportExplicitPlacesCheckBox = null;
+    private JCheckBox yawlExportGroupsCheckBox = null;
+
+    /**
+     * Constructor for ConfYAWLPanel.
+     */
+    public ConfYAWLPanel(String name) {
+        super(name);
+        initialize();
+    }
+
+    /**
+     * @see AbstractConfPanel#applyConfiguration()
+     */
+    public boolean applyConfiguration() {
+        ConfigurationManager.getConfiguration().setYAWLEnabled(getYAWLEnabledBox().isSelected());
+        ConfigurationManager.getConfiguration().setYAWLExportExplicitPlaces(getYAWLExportExplicitPlacesCheckBox().isSelected());
+        ConfigurationManager.getConfiguration().setYAWLExportGroups(getYAWLExportGroupsCheckBox().isSelected());
+
+        return true;
+    }
+
+    /**
+     * @see AbstractConfPanel#readConfiguration()
+     */
+    public void readConfiguration() {
+        getYAWLEnabledBox().setSelected(ConfigurationManager.getConfiguration().isYAWLEnabled());
+        getYAWLExportExplicitPlacesCheckBox().setSelected(ConfigurationManager.getConfiguration().isYAWLExportExplicitPlaces());
+        getYAWLExportGroupsCheckBox().setSelected(ConfigurationManager.getConfiguration().isYAWLExportGroups());
+
+        if(getYAWLEnabledBox().isSelected()) {
+            getYAWLOptionsPanel().setVisible(true);
+        }
+        else {
+            getYAWLOptionsPanel().setVisible(false);
+        }
+    }
+
+    private void initialize() {
+        JPanel contentPanel = new JPanel();
+        contentPanel.setLayout(new GridBagLayout());
+        GridBagConstraints c = new GridBagConstraints();
+        c.anchor = GridBagConstraints.NORTH;
+        c.fill = GridBagConstraints.HORIZONTAL;
+
+        c.weightx = 1;
+        c.gridx = 0;
+        c.gridy = 0;
+        contentPanel.add(getYAWLEnabledPanel(), c);
+
+        c.gridx = 0;
+        c.gridy = 1;
+        contentPanel.add(getYAWLOptionsPanel(), c);
+
+        // dummy
+        c.fill = GridBagConstraints.VERTICAL;
+        c.weighty = 1;
+        c.gridy = 2;
+        contentPanel.add(new JPanel(), c);
+
+        setMainPanel(contentPanel);
+    }
+
+    // Panels
+
+    /**
+     * Returns the YAWlEnabledPanel
+     *
+     * @return JPanel
+     */
+    private JPanel getYAWLEnabledPanel() {
+        if (YAWLEnabledPanel == null) {
+            YAWLEnabledPanel = new JPanel();
+            YAWLEnabledPanel.setLayout(new GridBagLayout());
+            GridBagConstraints c = new GridBagConstraints();
+            c.anchor = GridBagConstraints.WEST;
+            YAWLEnabledPanel.setBorder(BorderFactory.createCompoundBorder(
+                    BorderFactory.createTitledBorder(Messages.getString("Configuration.YAWL.Panel.YAWL.Title")),
+                    BorderFactory.createEmptyBorder(10, 10, 10, 10)));
+            c.weightx = 1;
+            c.gridx = 1;
+            c.gridy = 0;
+            YAWLEnabledPanel.add(getYAWLEnabledBox(), c);
+        }
+        return YAWLEnabledPanel;
+    }
+
+    /**
+     * Returns the YAWLPanel
+     *
+     * @return JPanel
+     */
+    private JPanel getYAWLOptionsPanel() {
+        if (YAWLOptionsPanel == null)
+        {
+            YAWLOptionsPanel = new JPanel();
+            YAWLOptionsPanel.setLayout(new GridBagLayout());
+            GridBagConstraints c = new GridBagConstraints();
+            c.anchor = GridBagConstraints.WEST;
+            YAWLOptionsPanel.setBorder(BorderFactory.createCompoundBorder(BorderFactory.createTitledBorder(Messages.getString("Configuration.YAWL.Panel.YAWL.Options.Title")), BorderFactory.createEmptyBorder(5, 5,
+                    10, 5)));
+            c.weightx = 1;
+            c.gridx = 0;
+            c.gridy = 0;
+            YAWLOptionsPanel.add(getYAWLExportExplicitPlacesCheckBox(), c);
+            c.gridx = 0;
+            c.gridy = 1;
+            YAWLOptionsPanel.add(getYAWLExportGroupsCheckBox(), c);
+        }
+        return YAWLOptionsPanel;
+    }
+
+    /**
+     * Returns the checkbox for switching between implicit and explicit places to YAWL
+     *
+     * @return  JCheckBox
+     */
+    private JCheckBox getYAWLExportExplicitPlacesCheckBox() {
+        if (yawlExportExplicitPlacesCheckBox == null)
+        {
+            yawlExportExplicitPlacesCheckBox = new JCheckBox();
+            yawlExportExplicitPlacesCheckBox.setText(Messages.getString("Configuration.YAWL.Panel.Export.ExplicitPlaces"));
+            yawlExportExplicitPlacesCheckBox.setToolTipText("<HTML>" + Messages.getString("Configuration.YAWL.Panel.Export.ExplicitPlaces.ToolTip") + "</HTML>");
+        }
+        return yawlExportExplicitPlacesCheckBox;
+    }
+
+    /**
+     * Returns the checkbox for switching between exporting groups
+     *
+     * @return  JCheckBox
+     */
+    private JCheckBox getYAWLExportGroupsCheckBox() {
+        if (yawlExportGroupsCheckBox == null)
+        {
+            yawlExportGroupsCheckBox = new JCheckBox();
+            yawlExportGroupsCheckBox.setText(Messages.getString("Configuration.YAWL.Panel.Export.Groups"));
+            yawlExportGroupsCheckBox.setToolTipText("<HTML>" + Messages.getString("Configuration.YAWL.Panel.Export.Groups.ToolTip") + "</HTML>");
+        }
+        return yawlExportGroupsCheckBox;
+    }
+
+    /**
+     * Returns the checkbox for activating the YAWL export suppport
+     *
+     * @return JCheckBox
+     */
+    private JCheckBox getYAWLEnabledBox() {
+        if (yawlEnabledBox == null) {
+            yawlEnabledBox = new JCheckBox(Messages.getString("Configuration.YAWL.Panel.Enabled"));
+            yawlEnabledBox.setEnabled(true);
+            yawlEnabledBox.setToolTipText("<html>" + Messages.getString("Configuration.YAWL.Panel.Enabled.Tooltip") + "</html>");
+            ItemListener listener = new ItemListener() {
+                @Override
+                public void itemStateChanged(ItemEvent e) {
+                    JCheckBox box = (JCheckBox) e.getSource();
+                    if(box == yawlEnabledBox) {
+                        if(box.isSelected()) {
+                            getYAWLOptionsPanel().setVisible(true);
+                        }
+                        else {
+                            getYAWLOptionsPanel().setVisible(false);
+                        }
+                    }
+                }
+            };
+            yawlEnabledBox.addItemListener(listener);
+        }
+        return yawlEnabledBox;
+    }
+}

--- a/WoPeD-FileInterface/src/main/java/org/woped/file/WoPeDToYAWL/YAWLConstants.java
+++ b/WoPeD-FileInterface/src/main/java/org/woped/file/WoPeDToYAWL/YAWLConstants.java
@@ -1,0 +1,110 @@
+package org.woped.file.WoPeDToYAWL;
+
+public class YAWLConstants {
+
+    // YAWL Nodes
+    public final static String SPECIFICATIONSET = "specificationSet";
+    public final static String SPECIFICATION = "specification";
+    public final static String DOCUMENTATION = "documentation";
+    public final static String METADATA = "metaData";
+    public final static String CREATOR = "creator";
+    public final static String DESCRIPTION = "description";
+    public final static String COVERAGE = "coverage";
+    public final static String VERSION = "version";
+    public final static String PERSISTENT = "persistent";
+    public final static String IDENTIFIER = "identifier";
+    public final static String DECOMPOSITION = "decomposition";
+    public final static String PROCESSCONTROLELEMENTS = "processControlElements";
+    public final static String INPUTCONDITION = "inputCondition";
+    public final static String OUTPUTCONDITION = "outputCondition";
+    public final static String FLOWSINTO = "flowsInto";
+    public final static String NEXTELEMENTREF = "nextElementRef";
+    public final static String TASK = "task";
+    public final static String NAME = "name";
+    public final static String JOIN = "join";
+    public final static String SPLIT = "split";
+    public final static String RESOURCING = "resourcing";
+    public final static String OFFER = "offer";
+    public final static String ALLOCATE = "allocate";
+    public final static String START = "start";
+    public final static String ISDEFAULTFLOW = "isDefaultFlow";
+    public final static String PREDICATE = "predicate";
+    public final static String DECOMPOSESTO = "decomposesTo";
+    public final static String LAYOUT = "layout";
+    public final static String CONDITION = "condition";
+
+    // Operators
+    public final static String AND = "and";
+    public final static String XOR = "xor";
+
+    // YAWL Attributes
+    public final static String ID = "id";
+    public final static String CODE = "code";
+    public final static String INITIATOR = "initiator";
+    public final static String ORDERING = "ordering";
+
+    // Layout Nodes
+    public final static String LOCALE = "locale";
+    public final static String SIZE = "size";
+    public final static String NET = "net";
+    public final static String BOUNDS = "bounds";
+    public final static String FRAME = "frame";
+    public final static String VIEWPORT = "viewport";
+    public final static String VERTEX = "vertex";
+    public final static String ATTRIBUTES = "attributes";
+    public final static String CONTAINER = "container";
+    public final static String LABEL = "label";
+    public final static String DECORATOR = "decorator";
+    public final static String POSITION = "position";
+    public final static String FLOW = "flow";
+    public final static String PORTS = "ports";
+    public final static String LINESTYLE = "lineStyle";
+
+    // Layout Attributes
+    public final static String LANGUAGE = "language";
+    public final static String COUNTRY = "country";
+    public final static String DEFAULTBGCOLOR = "defaultBgColor";
+    public final static String W = "w";
+    public final static String H = "h";
+    public final static String X = "x";
+    public final static String Y = "y";
+    public final static String BGCOLOR = "bgColor";
+    public final static String TYPE = "type";
+    public final static String SOURCE = "source";
+    public final static String TARGET = "target";
+    public final static String IN = "in";
+    public final static String OUT = "out";
+
+    // Layout Offsets
+    public final static int XOFFSET_LABEL = -32;
+    public final static int YOFFSET_LABEL = 32;
+    public final static int XOFFSET_SPLIT_DECORATOR = 31;
+    public final static int XOFFSET_JOIN_DECORATOR = -10;
+
+    // Resource Nodes
+    public final static String ORGDATA = "orgdata";
+    public final static String PARTICIPANTS = "participants";
+    public final static String PARTICIPANT = "participant";
+    public final static String USERID = "userid";
+    public final static String PASSWORD = "password";
+    public final static String FIRSTNAME = "firstname";
+    public final static String LASTNAME = "lastname";
+    public final static String NOTES = "notes";
+    public final static String ISADMINISTRATOR = "isAdministrator";
+    public final static String ROLES = "roles";
+    public final static String POSITIONS = "positions";
+    public final static String CAPABILITIES = "capabilities";
+    public final static String PRIVILEGES = "privileges";
+    public final static String ROLE = "role";
+    public final static String ORGGROUPS = "orggroups";
+    public final static String ORGGROUP = "orggroup";
+    public final static String GROUPNAME = "groupName";
+    public final static String GROUPTYPE = "groupType";
+    public final static String NONHUMANRESOURCES = "nonhumanresources";
+    public final static String NONHUMANCATEGORIES = "nonhumancategories";
+    public final static String DISTRIBUTIONSET = "distributionSet";
+    public final static String INITIALSET = "initialSet";
+
+    // Default Password
+    public final static String DEFAULTPASSWORD = "YAWL";
+}

--- a/WoPeD-FileInterface/src/main/java/org/woped/file/WoPeDToYAWL/YAWLExport.java
+++ b/WoPeD-FileInterface/src/main/java/org/woped/file/WoPeDToYAWL/YAWLExport.java
@@ -1,0 +1,948 @@
+package org.woped.file.WoPeDToYAWL;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.woped.core.config.ConfigurationManager;
+import org.woped.core.model.ModelElementContainer;
+import org.woped.core.model.PetriNetModelProcessor;
+import org.woped.core.model.petrinet.*;
+import org.woped.core.utilities.LoggerManager;
+import org.woped.editor.controller.vc.EditorVC;
+import org.woped.file.Constants;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.FileOutputStream;
+import java.util.Collection;
+import java.util.List;
+import java.util.Vector;
+
+public class YAWLExport {
+
+    private Document yawlDocument = null;
+    private Document resourceDocument = null;
+
+    private EditorVC editor = null;
+    // Layout-Element for the whole specification
+    private Element specificationLayout = null;
+    // Layout-Element for the current net, needed for multiple subnets
+    private Element netLayout = null;
+
+    /**
+     * Creates a new instance of an exporter.
+     */
+    public YAWLExport() {
+
+    }
+
+    /**
+     * Saves the petrinet to *.yawl File and its resources to *.ybkp.
+     *
+     * @param editor
+     * @param fileName
+     */
+    public void saveToFile(EditorVC editor, String fileName) {
+        LoggerManager.debug(Constants.FILE_LOGGER, "##### START YAWL EXPORT #####");
+        long start = System.currentTimeMillis();
+        this.editor = editor;
+
+        createYAWLDocument(fileName);
+
+        if (YAWLExportUtils.hasResources(editor)) {
+            createResourceDocument(fileName);
+        }
+        LoggerManager.debug(Constants.FILE_LOGGER, "Filename: " + fileName);
+        LoggerManager.debug(Constants.FILE_LOGGER, "##### END YAWL EXPORT ##### (" + (System.currentTimeMillis() - start) + " ms)");
+    }
+
+    /**
+     * Creates a new Document-instance.
+     *
+     * @return Document
+     */
+    private Document createNewDocument() {
+        DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder documentBuilder = null;
+        try {
+            documentBuilder = documentBuilderFactory.newDocumentBuilder();
+        } catch (ParserConfigurationException e) {
+            e.printStackTrace();
+        }
+        return documentBuilder.newDocument();
+    }
+
+    /**
+     * Creates the *.yawl File with all its elements.
+     *
+     * @param fileName
+     */
+    private void createYAWLDocument(String fileName) {
+        yawlDocument = createNewDocument();
+        // Build File Structure
+        Element specificationSet = initSpecificationSet();
+        Element metaData = initMetaData();
+        Element specification = initSpecification();
+        Element documentation = initDocumentation();
+        Element xsSchema = initXsSchema();
+        Element layout = initLayout();
+
+        specification.appendChild(documentation);
+        specification.appendChild(metaData);
+        specification.appendChild(xsSchema);
+
+        // Create the decompositions and processControlElements for the YAWL-net
+        initProcessControlElements(specification);
+
+        specificationSet.appendChild(specification);
+        specificationSet.appendChild(layout);
+
+        yawlDocument.appendChild(specificationSet);
+
+        // transform file to .yawl
+        transformFile(yawlDocument, fileName);
+    }
+
+    /**
+     * Creates the *.ybkp file with all its resources.
+     *
+     * @param fileName
+     */
+    private void createResourceDocument(String fileName) {
+        resourceDocument = createNewDocument();
+        fileName = fileName.replaceAll(".yawl", "Resources.ybkp");
+        // Build File Structure
+        Element orgdata = resourceDocument.createElement(YAWLConstants.ORGDATA);
+        Element participants = initParticipants();
+        Element roles = initRoles();
+        Element groups = initOrgGroups();
+
+        orgdata.appendChild(participants);
+        orgdata.appendChild(roles);
+        orgdata.appendChild(groups);
+
+        resourceDocument.appendChild(orgdata);
+
+        // transform file to .ybkp
+        transformFile(resourceDocument, fileName);
+    }
+
+    /**
+     * Creates and returns the participants-elements.
+     *
+     * @return Element the <participants>-element *.ybkp file
+     */
+    private Element initParticipants() {
+        Element participants = resourceDocument.createElement(YAWLConstants.PARTICIPANTS);
+
+        Vector<ResourceModel> resources = editor.getModelProcessor().getResources();
+
+        for (ResourceModel resource : resources) {
+            Element participant = resourceDocument.createElement(YAWLConstants.PARTICIPANT);
+            participant.setAttribute(YAWLConstants.ID, resource.getName());
+
+            // userID is a necessary field, otherwise only one object can be uploaded to the yawl resource engine
+            Element userID = resourceDocument.createElement(YAWLConstants.USERID);
+            Element password = resourceDocument.createElement(YAWLConstants.PASSWORD);
+            Element firstName = resourceDocument.createElement(YAWLConstants.FIRSTNAME);
+            // In WoPeD lastname is not required
+            Element lastName = resourceDocument.createElement(YAWLConstants.LASTNAME);
+            Element description = resourceDocument.createElement(YAWLConstants.DESCRIPTION);
+            Element notes = resourceDocument.createElement(YAWLConstants.NOTES);
+            Element isAdministrator = resourceDocument.createElement(YAWLConstants.ISADMINISTRATOR);
+            Element roles = resourceDocument.createElement(YAWLConstants.ROLES);
+            Element positions = resourceDocument.createElement(YAWLConstants.POSITIONS);
+            Element capabilities = resourceDocument.createElement(YAWLConstants.CAPABILITIES);
+            Element privileges = resourceDocument.createElement(YAWLConstants.PRIVILEGES);
+
+            // Check for '*'-delimiter in the name to set firstName and lastName
+            String resourceName = resource.getName();
+            String firstNameString = resourceName;
+            String lastNameString = "";
+            if(resource.getName().contains("*")) {
+                firstNameString = resourceName.split("\\*")[0];
+                lastNameString = resourceName.split("\\*")[1];
+            }
+            userID.appendChild(resourceDocument.createTextNode(firstNameString.toLowerCase()));
+            // Allocate a default password to each user
+            password.appendChild(resourceDocument.createTextNode(YAWLExportUtils.generateDefaultPassword()));
+
+            firstName.appendChild(resourceDocument.createTextNode(firstNameString));
+            lastName.appendChild(resourceDocument.createTextNode(lastNameString));
+
+            // Add roles to the participant
+            Vector<String> resourceRoles = YAWLExportUtils.getRolesForResource(editor, resource);
+
+            for (String resourceRole : resourceRoles) {
+                Element role = resourceDocument.createElement(YAWLConstants.ROLE);
+
+                role.appendChild(resourceDocument.createTextNode(resourceRole));
+
+                roles.appendChild(role);
+            }
+
+            participant.appendChild(userID);
+            participant.appendChild(password);
+            participant.appendChild(firstName);
+            participant.appendChild(lastName);
+            participant.appendChild(description);
+            participant.appendChild(notes);
+            participant.appendChild(isAdministrator);
+            participant.appendChild(roles);
+            participant.appendChild(positions);
+            participant.appendChild(capabilities);
+            participant.appendChild(privileges);
+
+            participants.appendChild(participant);
+        }
+        return participants;
+    }
+
+    /**
+     * Creates and returns the roles-elements.
+     *
+     * @return Element the <roles>-element *.ybkp file
+     */
+    private Element initRoles() {
+        Element roles = resourceDocument.createElement(YAWLConstants.ROLES);
+
+        Vector<ResourceClassModel> resources = editor.getModelProcessor().getRoles();
+
+        for (ResourceClassModel resource : resources) {
+            Element role = resourceDocument.createElement(YAWLConstants.ROLE);
+            role.setAttribute(YAWLConstants.ID, resource.getName());
+
+            Element name = resourceDocument.createElement(YAWLConstants.NAME);
+            Element description = resourceDocument.createElement(YAWLConstants.DESCRIPTION);
+            Element notes = resourceDocument.createElement(YAWLConstants.NOTES);
+
+            name.appendChild(resourceDocument.createTextNode(resource.getName()));
+
+            role.appendChild(name);
+            role.appendChild(description);
+            role.appendChild(notes);
+
+            roles.appendChild(role);
+        }
+        return roles;
+    }
+
+    /**
+     * Creates and returns the orggroups-elements.
+     *
+     * @return Element the <orggroups>-element *.ybkp file
+     */
+    private Element initOrgGroups() {
+        Element groups = resourceDocument.createElement(YAWLConstants.ORGGROUPS);
+
+        // Check if exportGroups is selected in settings
+        if (ConfigurationManager.getConfiguration().isYAWLExportGroups()) {
+            Vector<ResourceClassModel> resources = editor.getModelProcessor().getOrganizationUnits();
+
+            for (ResourceClassModel resource : resources) {
+                Element group = resourceDocument.createElement(YAWLConstants.ORGGROUP);
+                group.setAttribute(YAWLConstants.ID, resource.getName());
+
+                Element groupName = resourceDocument.createElement(YAWLConstants.GROUPNAME);
+                Element groupType = resourceDocument.createElement(YAWLConstants.GROUPTYPE);
+                Element description = resourceDocument.createElement(YAWLConstants.DESCRIPTION);
+                Element notes = resourceDocument.createElement(YAWLConstants.NOTES);
+
+                groupName.appendChild(resourceDocument.createTextNode(resource.getName()));
+                groupType.appendChild(resourceDocument.createTextNode("GROUP"));
+
+                group.appendChild(groupName);
+                group.appendChild(groupType);
+                group.appendChild(description);
+                group.appendChild(notes);
+
+                groups.appendChild(group);
+            }
+        }
+        return groups;
+    }
+
+    /**
+     * Creates and returns the layout-element.
+     *
+     * @return Element the <layout>-element of *.yawl file
+     */
+    private Element initLayout() {
+        Element layout = yawlDocument.createElement(YAWLConstants.LAYOUT);
+
+        Element locale = yawlDocument.createElement(YAWLConstants.LOCALE);
+        locale.setAttribute(YAWLConstants.LANGUAGE, "de");
+        locale.setAttribute(YAWLConstants.COUNTRY, "DE");
+
+        Element specification = yawlDocument.createElement(YAWLConstants.SPECIFICATION);
+        specification.setAttribute(YAWLConstants.ID, YAWLExportUtils.getNetName(editor));
+        specification.setAttribute(YAWLConstants.DEFAULTBGCOLOR, "-526351");
+
+        Element size = yawlDocument.createElement(YAWLConstants.SIZE);
+        size.setAttribute(YAWLConstants.W, "58");
+        size.setAttribute(YAWLConstants.H, "28");
+
+        Element net = createNet(YAWLExportUtils.getNetName(editor));
+
+        specification.appendChild(size);
+        specification.appendChild(net);
+
+        layout.appendChild(locale);
+        layout.appendChild(specification);
+
+        this.specificationLayout = specification;
+        this.netLayout = net;
+
+        return layout;
+    }
+
+    /**
+     * Creates and returns the specificationset-element.
+     *
+     * @return Element the <specificationset>-element of *.yawl file
+     */
+    private Element initSpecificationSet() {
+        Element specificationSet = yawlDocument.createElement(YAWLConstants.SPECIFICATIONSET);
+        specificationSet.setAttribute("xmlns", "http://www.yawlfoundation.org/yawlschema");
+        specificationSet.setAttribute("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance");
+        specificationSet.setAttribute("version", "4.0");
+        specificationSet.setAttribute("xsi:schemaLocation", "http://www.yawlfoundation.org/yawlschema http://www.yawlfoundation.org/yawlschema/YAWL_Schema4.0.xsd");
+
+        return specificationSet;
+    }
+
+    /**
+     * Creates and returns the specification-element.
+     *
+     * @return Element the <specification>-element of *.yawl file
+     */
+    private Element initSpecification() {
+        Element specification = yawlDocument.createElement(YAWLConstants.SPECIFICATION);
+
+        specification.setAttribute("uri", YAWLExportUtils.getNetName(editor));
+
+        return specification;
+    }
+
+    /**
+     * Creates and returns the documentation-element.
+     *
+     * @return Element the <documentation>-element of *.yawl file
+     */
+    private Element initDocumentation() {
+        Element documentation = yawlDocument.createElement(YAWLConstants.DOCUMENTATION);
+        documentation.appendChild(yawlDocument.createTextNode("No description provided"));
+
+        return documentation;
+    }
+
+    /**
+     * Creates and returns the metadata-element with its elements.
+     *
+     * @return Element the <metadata>-element of *.yawl file
+     */
+    private Element initMetaData() {
+        Element metaData = yawlDocument.createElement(YAWLConstants.METADATA);
+
+        Element creator = yawlDocument.createElement(YAWLConstants.CREATOR);
+        Element description = yawlDocument.createElement(YAWLConstants.DESCRIPTION);
+        Element coverage = yawlDocument.createElement(YAWLConstants.COVERAGE);
+        Element version = yawlDocument.createElement(YAWLConstants.VERSION);
+        Element persistent = yawlDocument.createElement(YAWLConstants.PERSISTENT);
+        Element identifier = yawlDocument.createElement(YAWLConstants.IDENTIFIER);
+
+        creator.appendChild(yawlDocument.createTextNode("Creator"));
+        description.appendChild(yawlDocument.createTextNode("No description provided"));
+        coverage.appendChild(yawlDocument.createTextNode("4.3.1.772"));
+        version.appendChild(yawlDocument.createTextNode("0.1"));
+        persistent.appendChild(yawlDocument.createTextNode("false"));
+        identifier.appendChild(yawlDocument.createTextNode("UID_1"));
+
+        metaData.appendChild(creator);
+        metaData.appendChild(description);
+        metaData.appendChild(coverage);
+        metaData.appendChild(version);
+        metaData.appendChild(persistent);
+        metaData.appendChild(identifier);
+
+        return metaData;
+    }
+
+    /**
+     * Creates and returns the xs:schema-element.
+     *
+     * @return Element the <xs:schema>-element of *.yawl file
+     */
+    private Element initXsSchema() {
+        Element xsSchema = yawlDocument.createElement("xs:schema");
+        xsSchema.setAttribute("xmlns:xs", "http://www.w3.org/2001/XMLSchema");
+
+        return xsSchema;
+    }
+
+    /**
+     * Creates and returns the decomposition-element.
+     *
+     * @return Element the <decomposition>-element of *.yawl file
+     */
+    private Element initDecomposition() {
+        Element decomposition = yawlDocument.createElement(YAWLConstants.DECOMPOSITION);
+        decomposition.setAttribute(YAWLConstants.ID, YAWLExportUtils.getNetName(editor));
+        decomposition.setAttribute("isRootNet", "true");
+        decomposition.setAttribute("xsi:type", "NetFactsType");
+
+        return decomposition;
+    }
+
+    /**
+     * Creates processControlElements-element of *.yawl file. This is the
+     *
+     * @param specification
+     */
+    private void initProcessControlElements(Element specification) {
+        // Get the Net and its elements
+        PetriNetModelProcessor petriNetModelProcessor = editor.getModelProcessor();
+        ModelElementContainer modelElementContainer = petriNetModelProcessor.getElementContainer();
+
+        initProcessControlElements(modelElementContainer, specification, initDecomposition(), netLayout);
+    }
+
+    /**
+     * Creates the processControlElements-element of *.yawl file.
+     *
+     * @param elementContainer the net containing all net-elements
+     * @param specification the specification to which the decomposition needs to be added
+     * @param decomposition the decomposition to which the processControlElements need to be added
+     * @param netLayout the layout to which the net-elements need to be added
+     */
+    private void initProcessControlElements(ModelElementContainer elementContainer, Element specification, Element decomposition, Element netLayout) {
+        Element processControlElements = yawlDocument.createElement(YAWLConstants.PROCESSCONTROLELEMENTS);
+
+        List<AbstractPetriNetElementModel> netElements = elementContainer.getRootElements();
+
+        // Iterate over all net elements
+        for (AbstractPetriNetElementModel element : netElements) {
+            Element node = null;
+
+            // Check if element is place and edit node
+            if (element.getType() == AbstractPetriNetElementModel.PLACE_TYPE) {
+                node = processPlaces(element, netLayout);
+            }
+            // Check if element is transition and edit node
+            if (element.getType() == AbstractPetriNetElementModel.TRANS_SIMPLE_TYPE || element.getType() == AbstractPetriNetElementModel.TRANS_OPERATOR_TYPE) {
+                node = processTransitions(element, netLayout);
+            }
+            // Check if element is subprocess and edit node
+            if (element.getType() == AbstractPetriNetElementModel.SUBP_TYPE) {
+                LoggerManager.debug(Constants.FILE_LOGGER, " ... Subprocess detected: (ID:" + element.getId() + ")");
+
+                node = processTransitions(element, netLayout);
+
+                Element decomposesTo = yawlDocument.createElement(YAWLConstants.DECOMPOSESTO);
+                decomposesTo.setAttribute(YAWLConstants.ID, YAWLExportUtils.getNormalizedString(element.getNameValue()));
+                node.appendChild(decomposesTo);
+
+                // Retrieve the subprocess container
+                ModelElementContainer subprocess = ((SubProcessModel) element).getSimpleTransContainer();
+
+                Element subDecomposition = yawlDocument.createElement(YAWLConstants.DECOMPOSITION);
+                subDecomposition.setAttribute(YAWLConstants.ID, YAWLExportUtils.getNormalizedString(element.getNameValue()));
+                subDecomposition.setAttribute("xsi:type", "NetFactsType");
+
+                // Add Layout for subnet elements
+                Element subnetLayout = createNet(YAWLExportUtils.getNormalizedString(element.getNameValue()));
+
+                initProcessControlElements(subprocess, specification, subDecomposition, subnetLayout);
+            }
+            // Add flowsInto-node for all elements except the sink
+            if (!element.isSink() && node != null) {
+                Collection<AbstractPetriNetElementModel> nextElements = YAWLExportUtils.getNextElements(element);
+
+                // Counter for XOR-Split predicate ordering
+                int counterXOR = -1;
+                // Iterate over every next element
+                for (AbstractPetriNetElementModel nextElement : nextElements) {
+                    Element flowsInto = yawlDocument.createElement(YAWLConstants.FLOWSINTO);
+
+                    Element nextElementRef = yawlDocument.createElement(YAWLConstants.NEXTELEMENTREF);
+                    String nextElementRefName = nextElement.getNameValue();
+
+                    nextElementRef.setAttribute(YAWLConstants.ID, YAWLExportUtils.getNormalizedString(nextElementRefName));
+
+                    flowsInto.appendChild(nextElementRef);
+
+                    // Get operator of element
+                    int operatorType = 0;
+                    if (element.getType() == AbstractPetriNetElementModel.TRANS_OPERATOR_TYPE) {
+                        operatorType = ((OperatorTransitionModel) element).getOperatorType();
+                    }
+                    // Add Default-flow and predicates for XOR-Splits
+                    // Check if element is an explicit or implicit XOR-Split
+                    if (operatorType == OperatorTransitionModel.XOR_SPLIT_TYPE ||
+                            operatorType == OperatorTransitionModel.XORJOIN_XORSPLIT_TYPE ||
+                            operatorType == OperatorTransitionModel.ANDJOIN_XORSPLIT_TYPE ||
+                            (YAWLExportUtils.isImplicitXORSplit(element) && !ConfigurationManager.getConfiguration().isYAWLExportExplicitPlaces())) {
+                        if (counterXOR == -1) {
+                            Element isDefaultFlow = yawlDocument.createElement(YAWLConstants.ISDEFAULTFLOW);
+
+                            flowsInto.appendChild(isDefaultFlow);
+                        } else {
+                            Element predicate = yawlDocument.createElement(YAWLConstants.PREDICATE);
+                            predicate.setAttribute(YAWLConstants.ORDERING, "" + counterXOR);
+                            predicate.appendChild(yawlDocument.createTextNode("true()"));
+
+                            flowsInto.appendChild(predicate);
+                        }
+                        ++counterXOR;
+                    }
+                    // Insert the flows into-element after the node's name-element
+                    node.insertBefore(flowsInto, node.getFirstChild().getNextSibling());
+
+                    // Add Layout for arc
+                    Element flow = createFlow(element, nextElement);
+                    netLayout.appendChild(flow);
+
+                    LoggerManager.debug(Constants.FILE_LOGGER, "   ... Arc (" + YAWLExportUtils.getNormalizedString(element.getNameValue()) + " -> " + YAWLExportUtils.getNormalizedString(nextElement.getNameValue()) + ") set");
+                }
+            }
+            if (node != null) {
+                // Insert the inputCondition at the beginning of processControlElements-element to be valid against yawl schema
+                if(element.isRoot()) {
+                    processControlElements.insertBefore(node, processControlElements.getFirstChild());
+                }
+                else {
+                    processControlElements.appendChild(node);
+                }
+            }
+        }
+        // Move the outputCondition at the end of processControlElements-element to be valid against yawl schema
+        NodeList nodeList = processControlElements.getElementsByTagName(YAWLConstants.OUTPUTCONDITION);
+        if(nodeList.getLength() > 0) {
+            Node sink = nodeList.item(0);
+            processControlElements.removeChild(nodeList.item(0));
+            processControlElements.appendChild(sink);
+        }
+
+        // Add the process control elements to the net/decomposition
+        decomposition.appendChild(processControlElements);
+        // Add the net/decomposition to the specification
+        specification.appendChild(decomposition);
+        // Add the net to the layout node
+        specificationLayout.appendChild(netLayout);
+    }
+
+    /**
+     * Sets the place node for the given net element and adds its layout to the layout-node.
+     *
+     * @param element, netLayout
+     * @return Element
+     */
+    private Element processPlaces(AbstractPetriNetElementModel element, Element netLayout) {
+        Element node = null;
+
+        // Add root-place
+        if (element.isRoot()) {
+            node = yawlDocument.createElement(YAWLConstants.INPUTCONDITION);
+        }
+        // Add sink-place
+        if (element.isSink()) {
+            node = yawlDocument.createElement(YAWLConstants.OUTPUTCONDITION);
+        }
+        // Add condition if explicit places is chosen in config
+        if (!element.isRoot() && !element.isSink() && ConfigurationManager.getConfiguration().isYAWLExportExplicitPlaces()) {
+            node = yawlDocument.createElement(YAWLConstants.CONDITION);
+        }
+
+        // Check if node is not null, node can be null if exportExplicitPlaces is false in config
+        if (node != null) {
+            Element name = yawlDocument.createElement(YAWLConstants.NAME);
+            name.appendChild(yawlDocument.createTextNode(YAWLExportUtils.getNormalizedString(element.getNameValue())));
+
+            node.appendChild(name);
+            node.setAttribute(YAWLConstants.ID, YAWLExportUtils.getNormalizedString(element.getNameValue()));
+
+            // Add layout for element
+            Element containerLayout = null;
+            Element vertexLayout = createVertex(element);
+            vertexLayout.setAttribute(YAWLConstants.ID, YAWLExportUtils.getNormalizedString(element.getNameValue()));
+
+            // Add layout for label of element
+            containerLayout = yawlDocument.createElement(YAWLConstants.CONTAINER);
+            containerLayout.setAttribute(YAWLConstants.ID, YAWLExportUtils.getNormalizedString(element.getNameValue()));
+
+            Element labelLayout = createLabel(element);
+
+            containerLayout.appendChild(vertexLayout);
+            containerLayout.appendChild(labelLayout);
+
+            if (containerLayout != null) {
+                netLayout.appendChild(containerLayout);
+            } else {
+                netLayout.appendChild(vertexLayout);
+            }
+            LoggerManager.debug(Constants.FILE_LOGGER, "   ... Condition " + "(ID:" + node.getAttribute(YAWLConstants.ID) + ") set");
+        }
+        return node;
+    }
+
+    /**
+     * Sets the transition node for the given net element and adds its layout to the layout-node.
+     *
+     * @param element, netLayout
+     * @return Element
+     */
+    private Element processTransitions(AbstractPetriNetElementModel element, Element netLayout) {
+        Element node = yawlDocument.createElement(YAWLConstants.TASK);
+
+        node.setAttribute(YAWLConstants.ID, YAWLExportUtils.getNormalizedString(element.getNameValue()));
+
+        Element name = yawlDocument.createElement(YAWLConstants.NAME);
+        Element join = yawlDocument.createElement(YAWLConstants.JOIN);
+        Element split = yawlDocument.createElement(YAWLConstants.SPLIT);
+        Element resourcing = yawlDocument.createElement(YAWLConstants.RESOURCING);
+
+        Element offer = yawlDocument.createElement(YAWLConstants.OFFER);
+        Element allocate = yawlDocument.createElement(YAWLConstants.ALLOCATE);
+        Element start = yawlDocument.createElement(YAWLConstants.START);
+
+        // join code="xor" and split code="and" seems to be the 'code' for atomic task without join-type and split-type
+        String joinString = YAWLConstants.XOR;
+        String splitString = YAWLConstants.AND;
+        // hasJoinDecorator and hasSplitDecorator used for layout, identifying if an element needs a decorator
+        boolean hasJoinDecorator = false;
+        boolean hasSplitDecorator = false;
+
+        // Check for explicit join- or split operator
+        if (element.getType() == AbstractPetriNetElementModel.TRANS_OPERATOR_TYPE) {
+            OperatorTransitionModel operator = (OperatorTransitionModel) element;
+            switch (operator.getOperatorType()) {
+                // AND-Split
+                case 101:
+                    splitString = YAWLConstants.AND;
+                    hasSplitDecorator = true;
+                    break;
+                // AND-Join
+                case 102:
+                    joinString = YAWLConstants.AND;
+                    hasJoinDecorator = true;
+                    break;
+                // XOR-Split
+                case 104:
+                    splitString = YAWLConstants.XOR;
+                    hasSplitDecorator = true;
+                    break;
+                // XOR-Join
+                case 105:
+                    joinString = YAWLConstants.XOR;
+                    hasJoinDecorator = true;
+                    break;
+                // XOR-Join-Split
+                case 106:
+                    joinString = splitString = YAWLConstants.XOR;
+                    hasJoinDecorator = true;
+                    hasSplitDecorator = true;
+                    break;
+                // AND-Join-Split
+                case 107:
+                    joinString = splitString = YAWLConstants.AND;
+                    hasJoinDecorator = true;
+                    hasSplitDecorator = true;
+                    break;
+                // AND-Join-XOR-Split
+                case 108:
+                    joinString = YAWLConstants.AND;
+                    splitString = YAWLConstants.XOR;
+                    hasJoinDecorator = true;
+                    hasSplitDecorator = true;
+                    break;
+                // XOR-Join-AND-Split
+                case 109:
+                    joinString = YAWLConstants.XOR;
+                    splitString = YAWLConstants.AND;
+                    hasJoinDecorator = true;
+                    hasSplitDecorator = true;
+                    break;
+                default:
+                    break;
+            }
+        }
+        // Check for implicit Joins and Splits if there is not already an explicit operator
+        if (!hasSplitDecorator && YAWLExportUtils.isImplicitXORSplit(element) && !ConfigurationManager.getConfiguration().isYAWLExportExplicitPlaces()) {
+            splitString = YAWLConstants.XOR;
+            hasSplitDecorator = true;
+        }
+        if (!hasJoinDecorator && YAWLExportUtils.isImplicitXORJoin(element) && !ConfigurationManager.getConfiguration().isYAWLExportExplicitPlaces()) {
+            joinString = YAWLConstants.XOR;
+            hasJoinDecorator = true;
+        }
+        if (!hasSplitDecorator && YAWLExportUtils.isImplicitANDSplit(element)) {
+            splitString = YAWLConstants.AND;
+            hasSplitDecorator = true;
+        }
+        if (!hasJoinDecorator && YAWLExportUtils.isImplicitANDJoin(element)) {
+            joinString = YAWLConstants.AND;
+            hasJoinDecorator = true;
+        }
+
+        join.setAttribute(YAWLConstants.CODE, joinString);
+        split.setAttribute(YAWLConstants.CODE, splitString);
+
+        // Check for resource trigger
+        if (YAWLExportUtils.isTransition(element)) {
+            TransitionModel transitionModel = (TransitionModel) element;
+            TransitionResourceModel resourceModel = transitionModel.getToolSpecific().getTransResource();
+            TriggerModel triggerModel = ((TransitionModel) element).getToolSpecific().getTrigger();
+
+            if (triggerModel != null && resourceModel != null && triggerModel.getTriggertype() == TriggerModel.TRIGGER_RESOURCE) {
+                offer.setAttribute(YAWLConstants.INITIATOR, "system");
+
+                Element distributionSet = yawlDocument.createElement(YAWLConstants.DISTRIBUTIONSET);
+                Element initialSet = yawlDocument.createElement(YAWLConstants.INITIALSET);
+
+                // Add the role to the task
+                String roleString = resourceModel.getTransRoleName();
+                Element role = yawlDocument.createElement(YAWLConstants.ROLE);
+                role.appendChild(yawlDocument.createTextNode(roleString));
+
+                allocate.setAttribute(YAWLConstants.INITIATOR, "user");
+                start.setAttribute(YAWLConstants.INITIATOR, "user");
+
+                initialSet.appendChild(role);
+                distributionSet.appendChild(initialSet);
+                offer.appendChild(distributionSet);
+            }
+            else {
+                offer.setAttribute(YAWLConstants.INITIATOR, "user");
+                allocate.setAttribute(YAWLConstants.INITIATOR, "user");
+                start.setAttribute(YAWLConstants.INITIATOR, "user");
+            }
+        }
+        resourcing.appendChild(offer);
+        resourcing.appendChild(allocate);
+        resourcing.appendChild(start);
+
+        name.appendChild(yawlDocument.createTextNode(element.getNameValue()));
+
+        node.appendChild(name);
+        node.appendChild(join);
+        node.appendChild(split);
+        node.appendChild(resourcing);
+
+        // Add Layout for the task
+        Element containerLayout = yawlDocument.createElement(YAWLConstants.CONTAINER);
+        Element vertexLayout = createVertex(element);
+        Element labelLayout = createLabel(element);
+
+        containerLayout.setAttribute(YAWLConstants.ID, "" + YAWLExportUtils.getNormalizedString(element.getNameValue()));
+
+        // Add the Join-Decorator for the task
+        if (hasJoinDecorator) {
+            Element decorator = yawlDocument.createElement(YAWLConstants.DECORATOR);
+            Element position = yawlDocument.createElement(YAWLConstants.POSITION);
+            Element attributes = yawlDocument.createElement(YAWLConstants.ATTRIBUTES);
+            Element bounds = yawlDocument.createElement(YAWLConstants.BOUNDS);
+
+            decorator.setAttribute(YAWLConstants.TYPE, joinString.toUpperCase() + "_join");
+            position.appendChild(yawlDocument.createTextNode("12"));
+            bounds.setAttribute(YAWLConstants.X, "" + (element.getX() + YAWLConstants.XOFFSET_JOIN_DECORATOR));
+            bounds.setAttribute(YAWLConstants.Y, "" + element.getY());
+            bounds.setAttribute(YAWLConstants.W, "11");
+            bounds.setAttribute(YAWLConstants.H, "32");
+
+            attributes.appendChild(bounds);
+            decorator.appendChild(position);
+            decorator.appendChild(attributes);
+
+            containerLayout.appendChild(decorator);
+        }
+        // Add the Split-Decorator for the task
+        if (hasSplitDecorator) {
+            Element decorator = yawlDocument.createElement(YAWLConstants.DECORATOR);
+            Element position = yawlDocument.createElement(YAWLConstants.POSITION);
+            Element attributes = yawlDocument.createElement(YAWLConstants.ATTRIBUTES);
+            Element bounds = yawlDocument.createElement(YAWLConstants.BOUNDS);
+
+            decorator.setAttribute(YAWLConstants.TYPE, splitString.toUpperCase() + "_split");
+            position.appendChild(yawlDocument.createTextNode("13"));
+            bounds.setAttribute(YAWLConstants.X, "" + (element.getX() + YAWLConstants.XOFFSET_SPLIT_DECORATOR));
+            bounds.setAttribute(YAWLConstants.Y, "" + element.getY());
+            bounds.setAttribute(YAWLConstants.W, "11");
+            bounds.setAttribute(YAWLConstants.H, "32");
+
+            attributes.appendChild(bounds);
+            decorator.appendChild(position);
+            decorator.appendChild(attributes);
+
+            containerLayout.appendChild(decorator);
+        }
+        containerLayout.appendChild(vertexLayout);
+        containerLayout.appendChild(labelLayout);
+
+        netLayout.appendChild(containerLayout);
+
+        LoggerManager.debug(Constants.FILE_LOGGER, "   ... Task " + "(ID:" + node.getAttribute(YAWLConstants.ID) + ") set");
+
+        return node;
+    }
+
+    /**
+     * Creates a vertex-Element for the layout-part of an element.
+     * @param element
+     * @return Element
+     */
+    private Element createVertex(AbstractPetriNetElementModel element) {
+        Element vertex = yawlDocument.createElement(YAWLConstants.VERTEX);
+
+        Element attributes = yawlDocument.createElement(YAWLConstants.ATTRIBUTES);
+
+        Element bounds = yawlDocument.createElement(YAWLConstants.BOUNDS);
+        bounds.setAttribute(YAWLConstants.X, "" + element.getX());
+        bounds.setAttribute(YAWLConstants.Y, "" + element.getY());
+        bounds.setAttribute(YAWLConstants.W, "32");
+        bounds.setAttribute(YAWLConstants.H, "32");
+
+        attributes.appendChild(bounds);
+
+        vertex.appendChild(attributes);
+
+        return vertex;
+    }
+
+    /**
+     * Creates a label-Element for the layout-part of an element.
+     * @param element
+     * @return Element
+     */
+    private Element createLabel(AbstractPetriNetElementModel element) {
+        Element label = yawlDocument.createElement(YAWLConstants.LABEL);
+        Element attributes = yawlDocument.createElement(YAWLConstants.ATTRIBUTES);
+        Element bounds = yawlDocument.createElement(YAWLConstants.BOUNDS);
+
+        bounds.setAttribute(YAWLConstants.X, "" + (element.getX() + YAWLConstants.XOFFSET_LABEL));
+        bounds.setAttribute(YAWLConstants.Y, "" + (element.getY() + YAWLConstants.YOFFSET_LABEL));
+        //bounds.setAttribute(YAWLConstants.X, "" + (element.getNameModel().getX() + YAWLConstants.XOFFSET_LABEL));
+        //bounds.setAttribute(YAWLConstants.Y, "" + (element.getNameModel().getY()));
+        bounds.setAttribute(YAWLConstants.W, "96");
+        bounds.setAttribute(YAWLConstants.H, "20");
+
+        attributes.appendChild(bounds);
+        label.appendChild(attributes);
+
+        return label;
+    }
+
+    private Element createNet(String netName) {
+        Element net = yawlDocument.createElement(YAWLConstants.NET);
+        net.setAttribute(YAWLConstants.ID, netName);
+        net.setAttribute(YAWLConstants.BGCOLOR, "-526351");
+
+        Element bounds = yawlDocument.createElement(YAWLConstants.BOUNDS);
+        bounds.setAttribute(YAWLConstants.X, "0");
+        bounds.setAttribute(YAWLConstants.Y, "0");
+        bounds.setAttribute(YAWLConstants.W, "1684");
+        bounds.setAttribute(YAWLConstants.H, "651");
+
+        Element frame = yawlDocument.createElement(YAWLConstants.FRAME);
+        frame.setAttribute(YAWLConstants.X, "0");
+        frame.setAttribute(YAWLConstants.Y, "0");
+        frame.setAttribute(YAWLConstants.W, "1687");
+        frame.setAttribute(YAWLConstants.H, "654");
+
+        Element viewport = yawlDocument.createElement(YAWLConstants.VIEWPORT);
+        viewport.setAttribute(YAWLConstants.X, "0");
+        viewport.setAttribute(YAWLConstants.Y, "0");
+        viewport.setAttribute(YAWLConstants.W, "1687");
+        viewport.setAttribute(YAWLConstants.H, "654");
+
+        net.appendChild(bounds);
+        net.appendChild(frame);
+        net.appendChild(viewport);
+
+        return net;
+    }
+
+    /**
+     * Returns the flow-Element that represents the layout of an arc in a YAWL-net.
+     *
+     * @param source
+     * @param target
+     * @return Element
+     */
+    private Element createFlow(AbstractPetriNetElementModel source, AbstractPetriNetElementModel target) {
+        Element flow = yawlDocument.createElement(YAWLConstants.FLOW);
+        flow.setAttribute(YAWLConstants.SOURCE, YAWLExportUtils.getNormalizedString(source.getNameValue()));
+        flow.setAttribute(YAWLConstants.TARGET, YAWLExportUtils.getNormalizedString(target.getNameValue()));
+
+        Element ports = yawlDocument.createElement(YAWLConstants.PORTS);
+
+        int xDiff = target.getX() - source.getX();
+        int yDiff = target.getY() - source.getY();
+
+        // Target is to the right
+        if (xDiff > 0) {
+            ports.setAttribute(YAWLConstants.IN, "13");
+            ports.setAttribute(YAWLConstants.OUT, "12");
+        }
+        // Target is to the left
+        if (xDiff < 0) {
+            ports.setAttribute(YAWLConstants.IN, "12");
+            ports.setAttribute(YAWLConstants.OUT, "13");
+        }
+        // Target is below
+        if (yDiff > 0 && xDiff == 0) {
+            ports.setAttribute(YAWLConstants.IN, "12");
+            ports.setAttribute(YAWLConstants.OUT, "12");
+        }
+        // Target is above
+        if (yDiff < 0 && xDiff == 0) {
+            ports.setAttribute(YAWLConstants.IN, "13");
+            ports.setAttribute(YAWLConstants.OUT, "13");
+        }
+        // Check if source or target are operators, in which case the 'in' and 'out' ports have to be changed
+        if (source.getType() == AbstractPetriNetElementModel.TRANS_OPERATOR_TYPE || YAWLExportUtils.isImplicitANDSplit(source) || YAWLExportUtils.isImplicitXORSplit(source)) {
+            ports.setAttribute(YAWLConstants.IN, "13");
+        }
+        if (target.getType() == AbstractPetriNetElementModel.TRANS_OPERATOR_TYPE || YAWLExportUtils.isImplicitANDJoin(target) || YAWLExportUtils.isImplicitXORJoin(target)) {
+            ports.setAttribute(YAWLConstants.OUT, "12");
+        }
+
+        Element attributes = yawlDocument.createElement(YAWLConstants.ATTRIBUTES);
+        Element lineStyle = yawlDocument.createElement(YAWLConstants.LINESTYLE);
+        lineStyle.appendChild(yawlDocument.createTextNode("11"));
+
+        attributes.appendChild(lineStyle);
+
+        flow.appendChild(ports);
+        flow.appendChild(attributes);
+
+        return flow;
+    }
+
+    /**
+     * Transforms the XML to the YAWL-file.
+     *
+     * @param document
+     * @param fileName
+     */
+    private void transformFile(Document document, String fileName) {
+        try {
+            TransformerFactory transformerFactory = TransformerFactory.newInstance();
+            Transformer transformer = transformerFactory.newTransformer();
+            transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+            transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
+            DOMSource domSource = new DOMSource(document);
+            StreamResult streamResult = new StreamResult(new FileOutputStream(fileName));
+
+            transformer.transform(domSource, streamResult);
+        } catch (Exception e) {
+            LoggerManager.warn(Constants.FILE_LOGGER, "Could not transform YAWL-file: " + e.getMessage());
+        }
+    }
+}

--- a/WoPeD-FileInterface/src/main/java/org/woped/file/WoPeDToYAWL/YAWLExportUtils.java
+++ b/WoPeD-FileInterface/src/main/java/org/woped/file/WoPeDToYAWL/YAWLExportUtils.java
@@ -1,0 +1,248 @@
+package org.woped.file.WoPeDToYAWL;
+
+import org.woped.core.Constants;
+import org.woped.core.config.ConfigurationManager;
+import org.woped.core.model.ArcModel;
+import org.woped.core.model.ModelElementContainer;
+import org.woped.core.model.petrinet.AbstractPetriNetElementModel;
+import org.woped.core.model.petrinet.ResourceClassModel;
+import org.woped.core.model.petrinet.ResourceModel;
+import org.woped.core.utilities.LoggerManager;
+import org.woped.editor.controller.vc.EditorVC;
+
+import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.Vector;
+
+public class YAWLExportUtils {
+
+    /**
+     * Returns the net name of the given editor.
+     *
+     * @param editor
+     * @return String
+     */
+    public static String getNetName(EditorVC editor) {
+        return editor.getName().substring(0, editor.getName().indexOf("."));
+    }
+
+    /**
+     * Returns a normalized id for the id-attribute of a node. Replaces whitespaces with underscores.
+     *
+     * @param id
+     * @return String
+     */
+    public static String getNormalizedString(String id) {
+        return id.replaceAll(" ", "_");
+    }
+
+    /**
+     * Returns true if the modelElementContainer has resources attached.
+     * Returns false if the modelElementContainer has no resources attached.
+     *
+     * @param editor
+     * @return boolean
+     */
+    public static boolean hasResources(EditorVC editor) {
+        return !editor.getModelProcessor().getResources().isEmpty() || !editor.getModelProcessor().getRoles().isEmpty() || !editor.getModelProcessor().getOrganizationUnits().isEmpty();
+    }
+
+    /**
+     * Returns the roles that a resource is assigned to.
+     *
+     * @param editor
+     * @param resource
+     * @return Vector<String>
+     */
+    public static Vector<String> getRolesForResource(EditorVC editor, ResourceModel resource) {
+        Vector<String> resourceRoles = editor.getModelProcessor().getResourceClassesResourceIsAssignedTo(resource.getName());
+        // Remove groups from the assignments
+        Vector<ResourceClassModel> groups = editor.getModelProcessor().getOrganizationUnits();
+        Vector<String> groupsString = new Vector<>();
+        for (ResourceClassModel group : groups) {
+            groupsString.add(group.getName());
+        }
+        resourceRoles.removeAll(groupsString);
+
+        return resourceRoles;
+    }
+
+    /**
+     * Returns a default password using Base64 as encoding.
+     *
+     * @return String
+     */
+    public static synchronized String generateDefaultPassword() {
+        String encodedString = "";
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA");
+            md.update(YAWLConstants.DEFAULTPASSWORD.getBytes("UTF-8"));
+            byte raw[] = md.digest();
+            encodedString = Base64.getEncoder().encodeToString(raw);
+
+        } catch (Exception e) {
+            LoggerManager.error(Constants.CORE_LOGGER, "Default Password could not be generated!");
+        }
+        return encodedString;
+    }
+
+    /**
+     * Returns whether the AbstractPetriNetElementModel is a transition or not.
+     *
+     * @param element
+     * @return boolean
+     */
+    public static boolean isTransition(AbstractPetriNetElementModel element) {
+        int type = element.getType();
+        if(type == AbstractPetriNetElementModel.TRANS_SIMPLE_TYPE || type == AbstractPetriNetElementModel.TRANS_OPERATOR_TYPE || type == AbstractPetriNetElementModel.SUBP_TYPE) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Returns whether the AbstractPetriNetElementModel is a implicit XOR-Split or not.
+     *
+     * @param element
+     * @return boolean
+     */
+    public static boolean isImplicitXORSplit(AbstractPetriNetElementModel element) {
+        if (isTransition(element)) {
+            Collection<AbstractPetriNetElementModel> nextElements = getImmediateNextElements(element);
+            // interpret XOR-Split
+            if (nextElements.size() == 1) {
+                // Check if there is one place that enables a XOR-Split
+                for (AbstractPetriNetElementModel nextElement : nextElements) {
+                    if (nextElement.getType() == AbstractPetriNetElementModel.PLACE_TYPE && getImmediateNextElements(nextElement).size() > 1) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns whether the AbstractPetriNetElementModel is a implicit XOR-Join or not.
+     *
+     * @param element
+     * @return boolean
+     */
+    public static boolean isImplicitXORJoin(AbstractPetriNetElementModel element) {
+        if (isTransition(element)) {
+            Collection<AbstractPetriNetElementModel> previousElements = getPreviousElements(element);
+            // interpret XOR-Join
+            if (previousElements.size() == 1) {
+                // Check if there is one place that enables a XOR-Join
+                for (AbstractPetriNetElementModel previousElement : previousElements) {
+                    if (previousElement.getType() == AbstractPetriNetElementModel.PLACE_TYPE && getPreviousElements(previousElement).size() > 1) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns whether the AbstractPetriNetElementModel is a implicit AND-Split or not.
+     *
+     * @param element
+     * @return boolean
+     */
+    public static boolean isImplicitANDSplit(AbstractPetriNetElementModel element) {
+        if (isTransition(element)) {
+            Collection<AbstractPetriNetElementModel> nextElements = getImmediateNextElements(element);
+
+            if(nextElements.size() > 1) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns whether the AbstractPetriNetElementModel is a implicit AND-Join or not.
+     *
+     * @param element
+     * @return boolean
+     */
+    public static boolean isImplicitANDJoin(AbstractPetriNetElementModel element) {
+        if (isTransition(element)) {
+            Collection<AbstractPetriNetElementModel> previousElements = getPreviousElements(element);
+
+            if (previousElements.size() > 1) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns the immediate next Elements for a given Net element disregarding the configuration of the export for explicit conditions.
+     *
+     * @param element
+     * @return Collection<AbstractPetriNetElementModel> with the nextElements
+     */
+    private static Collection<AbstractPetriNetElementModel> getImmediateNextElements(AbstractPetriNetElementModel element) {
+        ModelElementContainer modelElementContainer = element.getRootOwningContainer();
+        Collection<AbstractPetriNetElementModel> nextElements = new ArrayList<>();
+
+        for (ArcModel arc : modelElementContainer.getArcMap().values()) {
+            if (arc.getSourceId() == element.getId()) {
+                nextElements.add(modelElementContainer.getElementById(arc.getTargetId()));
+            }
+        }
+
+        return nextElements;
+    }
+
+    /**
+     * Returns the next elements of an element. Next elements regarding the configuration of the export for explicit conditions.
+     *
+     * @param element
+     * @return Collection<AbstractPetriNetElementModel>
+     */
+    public static Collection<AbstractPetriNetElementModel> getNextElements(AbstractPetriNetElementModel element) {
+        if (ConfigurationManager.getConfiguration().isYAWLExportExplicitPlaces()) {
+            return getImmediateNextElements(element);
+        } else {
+            Collection<AbstractPetriNetElementModel> result = new ArrayList<>();
+
+            Collection<AbstractPetriNetElementModel> nextElements = getImmediateNextElements(element);
+
+            for (AbstractPetriNetElementModel nextElement : nextElements) {
+                // If next element is a place and not the sink, then retrieve the places' next elements
+                if (nextElement.getType() == AbstractPetriNetElementModel.PLACE_TYPE && !nextElement.isSink()) {
+                    Collection<AbstractPetriNetElementModel> nextElementsAfterPlace = getImmediateNextElements(nextElement);
+                    for (AbstractPetriNetElementModel nextElementAfterPlace : nextElementsAfterPlace) {
+                        result.add(nextElementAfterPlace);
+                    }
+                } else {
+                    result.add(nextElement);
+                }
+            }
+            return result;
+        }
+    }
+
+    /**
+     * Returns the previous Elements for a given Net element.
+     *
+     * @param element
+     * @return Collection<AbstractPetriNetElementModel>
+     */
+    public static Collection<AbstractPetriNetElementModel> getPreviousElements(AbstractPetriNetElementModel element) {
+        ModelElementContainer modelElementContainer = element.getRootOwningContainer();
+        Collection<AbstractPetriNetElementModel> previousElements = new ArrayList<>();
+
+        for (ArcModel arc : modelElementContainer.getArcMap().values()) {
+            if (arc.getTargetId().equals(element.getId())) {
+                previousElements.add(modelElementContainer.getElementById(arc.getSourceId()));
+            }
+        }
+        return previousElements;
+    }
+}

--- a/WoPeD-GUI/src/main/resources/Messages.properties
+++ b/WoPeD-GUI/src/main/resources/Messages.properties
@@ -1280,6 +1280,15 @@ Configuration.Tools.Panel.Woflan.UseWoflanDLL.Text 					= Use Woflan.dll (Window
 Configuration.Tools.Panel.Woflan.UseWoflanDLL.Text.ToolTip			= Use Woflan.dll  for soundness analysis
 Configuration.Tools.Panel.Woflan.WoflanPath.Text.ToolTip			= Path to \"wofapp.exe\"
 Configuration.Tools.Panel.Woflan.WhatsWoflan.Label					= What is Woflan?
+Configuration.YAWL.Title                                            = YAWL
+Configuration.YAWL.Panel.YAWL.Title                                 = YAWL
+Configuration.YAWL.Panel.YAWL.Options.Title                         = YAWL Options
+Configuration.YAWL.Panel.Enabled								    = Activate YAWL Support
+Configuration.YAWL.Panel.Enabled.Tooltip						    = Allows to save nets in the YAWL-Dataformat
+Configuration.YAWL.Panel.Export.ExplicitPlaces                      = Export *.yawl files with explicit conditions
+Configuration.YAWL.Panel.Export.ExplicitPlaces.ToolTip              = All places in the petrinet will be exported to explicit conditions in YAWL
+Configuration.YAWL.Panel.Export.Groups                              = Export *.ybkp files with groups
+Configuration.YAWL.Panel.Export.Groups.ToolTip                      = All groups from the resource editor will be exported to OrgGroups in YAWL
 #*************
 ! Transition
 #*************

--- a/WoPeD-GUI/src/main/resources/Messages_de.properties
+++ b/WoPeD-GUI/src/main/resources/Messages_de.properties
@@ -823,6 +823,15 @@ Configuration.Tools.Panel.Woflan.UseWoflanDLL.Text 					= Woflan.dll verwenden (
 Configuration.Tools.Panel.Woflan.UseWoflanDLL.Text.ToolTip			= Woflan.dll f\u00FCr Soundness Analyse verwenden
 Configuration.Tools.Panel.Woflan.WoflanPath.Text.ToolTip			= Pfad zu \"wofapp.exe\"
 Configuration.Tools.Panel.Woflan.WhatsWoflan.Label					= Was ist Woflan?
+Configuration.YAWL.Title                                            = YAWL
+Configuration.YAWL.Panel.YAWL.Title                                 = YAWL
+Configuration.YAWL.Panel.YAWL.Options.Title                         = YAWL Einstellungen
+Configuration.YAWL.Panel.Enabled								    = YAWL Unterstützung aktivieren
+Configuration.YAWL.Panel.Enabled.Tooltip						    = Ermöglicht das Abspeichern von Netzen in das YAWL-Dateiformat
+Configuration.YAWL.Panel.Export.ExplicitPlaces                      = *.yawl Dateien mit expliziten Conditions exportieren
+Configuration.YAWL.Panel.Export.ExplicitPlaces.ToolTip              = Alle Stellen im Petrinetz werden zu Conditions in YAWL exportiert
+Configuration.YAWL.Panel.Export.Groups                              = *.ybkp Dateien mit Gruppen exportieren
+Configuration.YAWL.Panel.Export.Groups.ToolTip                      = Alle Gruppen im Ressourcen Editor werden zu OrgGroups in YAWL exportiert
 #*************
 ! Exit-Config
 #*************

--- a/WoPeD-UnitTests/src/test/java/org/woped/file/YAWLExportUtilsTest.java
+++ b/WoPeD-UnitTests/src/test/java/org/woped/file/YAWLExportUtilsTest.java
@@ -1,0 +1,457 @@
+package org.woped.file;
+
+import org.jgraph.graph.DefaultPort;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.woped.core.config.ConfigurationManager;
+import org.woped.core.model.ArcModel;
+import org.woped.core.model.CreationMap;
+import org.woped.core.model.ModelElementContainer;
+import org.woped.core.model.PetriNetModelProcessor;
+import org.woped.core.model.petrinet.*;
+import org.woped.editor.controller.vc.EditorVC;
+import org.woped.file.WoPeDToYAWL.YAWLExportUtils;
+
+import java.awt.geom.Point2D;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Vector;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class YAWLExportUtilsTest {
+
+    @Before
+    public void setUp() {
+        ConfigurationManager.setConfiguration(ConfigurationManager.getStandardConfiguration());
+    }
+
+    @After
+    public void tearDown() {
+        ConfigurationManager.setConfiguration(ConfigurationManager.getStandardConfiguration());
+    }
+
+    @Test
+    public void getNetName_test_Returnstest() {
+        EditorVC editor = mock(EditorVC.class);
+        when(editor.getName()).thenReturn("test.yawl");
+
+        String netName = YAWLExportUtils.getNetName(editor);
+
+        assertEquals("test", netName);
+    }
+
+    @Test
+    public void getNormalizedString_MaxMustermann_ReturnsMax_Mustermann() {
+        String input = "Max Mustermann";
+
+        assertEquals("Max_Mustermann", YAWLExportUtils.getNormalizedString(input));
+    }
+
+    @Test
+    public void hasResources_notEmpty_Returnstrue() {
+        EditorVC editor = mock(EditorVC.class);
+        PetriNetModelProcessor modelProcessor = mock(PetriNetModelProcessor.class);
+
+        Vector<ResourceModel> resourceModel = new Vector<>();
+        ResourceModel participantA = new ResourceModel("Max");
+        resourceModel.add(participantA);
+        Vector<ResourceClassModel> rolesModel = new Vector<>();
+        Vector<ResourceClassModel> groupsModel = new Vector<>();
+
+        when(editor.getModelProcessor()).thenReturn(modelProcessor);
+
+        when(editor.getModelProcessor().getResources()).thenReturn(resourceModel);
+        when(editor.getModelProcessor().getRoles()).thenReturn(rolesModel);
+        when(editor.getModelProcessor().getOrganizationUnits()).thenReturn(groupsModel);
+
+        boolean hasResources = YAWLExportUtils.hasResources(editor);
+
+        assertTrue(hasResources);
+    }
+
+    @Test
+    public void hasResources_empty_Returnsfalse() {
+        EditorVC editor = mock(EditorVC.class);
+        PetriNetModelProcessor modelProcessor = mock(PetriNetModelProcessor.class);
+
+        Vector<ResourceModel> resourcesModel = new Vector<>();
+        Vector<ResourceClassModel> rolesModel = new Vector<>();
+        Vector<ResourceClassModel> groupsModel = new Vector<>();
+
+        when(editor.getModelProcessor()).thenReturn(modelProcessor);
+
+        when(editor.getModelProcessor().getResources()).thenReturn(resourcesModel);
+        when(editor.getModelProcessor().getRoles()).thenReturn(rolesModel);
+        when(editor.getModelProcessor().getOrganizationUnits()).thenReturn(groupsModel);
+
+        boolean hasResources = YAWLExportUtils.hasResources(editor);
+
+        assertFalse(hasResources);
+    }
+
+    @Test
+    public void getRolesForResource_MaxIsManager_ReturnsManager() {
+        PetriNetModelProcessor processor = Mockito.mock(PetriNetModelProcessor.class);
+        EditorVC editor = Mockito.mock(EditorVC.class);
+        ResourceModel testResource = new ResourceModel("Max");
+        Vector<String> resourceIsAssignedTo = new Vector<>();
+        resourceIsAssignedTo.add("Manager");
+
+        when(editor.getModelProcessor()).thenReturn(processor);
+        when(processor.getResourceClassesResourceIsAssignedTo(testResource.getName())).thenReturn(resourceIsAssignedTo);
+        when(processor.getOrganizationUnits()).thenReturn(new Vector<>());
+
+        Vector<String> rolesForResource = YAWLExportUtils.getRolesForResource(editor, testResource);
+
+        assertEquals("Manager", rolesForResource.get(0));
+    }
+
+    @Test
+    public void generateDefaultPassword_ReturnsEncodedYAWLString() {
+        String encodedPassword = YAWLExportUtils.generateDefaultPassword();
+
+        assertEquals("Se4tMaQCi9gr0Q2usp7P56Sk5vM=", encodedPassword);
+    }
+
+    @Test
+    public void isTransition_SimpleTrans_ReturnsTrue() {
+        TransitionModel transition = new TransitionModel(CreationMap.createMap());
+
+        assertTrue(YAWLExportUtils.isTransition(transition));
+    }
+
+    @Test
+    public void isTransition_Place_ReturnsFalse() {
+        PlaceModel place = new PlaceModel(CreationMap.createMap());
+
+        assertFalse(YAWLExportUtils.isTransition(place));
+    }
+
+    @Test
+    public void isImplicitXORSplit_ImplicitXORSplit_ReturnsTrue() {
+        // Create the elements and arcs
+        ModelElementContainer container = new ModelElementContainer();
+        TransitionModel t1 = new TransitionModel(CreationMap.createMap());
+        t1.setId("t1");
+        TransitionModel t2 = new TransitionModel(CreationMap.createMap());
+        t2.setId("t2");
+        TransitionModel t3 = new TransitionModel(CreationMap.createMap());
+        t3.setId("t3");
+        PlaceModel p1 = new PlaceModel(CreationMap.createMap());
+        p1.setId("p1");
+        DemoArcModelData a1 = new DemoArcModelData("a1", "t1", "p1", 1);
+        DemoArcModelData a2 = new DemoArcModelData("a2", "p1", "t2", 1);
+        DemoArcModelData a3 = new DemoArcModelData("a3", "p1", "t3", 1);
+
+        // Build the net
+        container.addElement(t1);
+        container.addElement(t2);
+        container.addElement(t3);
+        container.addElement(p1);
+        container.addReference(a1.arc);
+        container.addReference(a2.arc);
+        container.addReference(a3.arc);
+
+        assertTrue(YAWLExportUtils.isImplicitXORSplit(t1));
+    }
+
+    @Test
+    public void isImplicitXORSplit_NoImplicitXORSplit_ReturnsFalse() {
+        // Create the elements and arcs
+        ModelElementContainer container = new ModelElementContainer();
+        TransitionModel t1 = new TransitionModel(CreationMap.createMap());
+        t1.setId("t1");
+        TransitionModel t2 = new TransitionModel(CreationMap.createMap());
+        t2.setId("t2");
+        PlaceModel p1 = new PlaceModel(CreationMap.createMap());
+        p1.setId("p1");
+        DemoArcModelData a1 = new DemoArcModelData("a1", "t1", "p1", 1);
+        DemoArcModelData a2 = new DemoArcModelData("a2", "p1", "t2", 1);
+
+        // Build the net
+        container.addElement(t1);
+        container.addElement(t2);
+        container.addElement(p1);
+        container.addReference(a1.arc);
+        container.addReference(a2.arc);
+
+        assertFalse(YAWLExportUtils.isImplicitXORSplit(t1));
+    }
+
+    @Test
+    public void isImplicitXORJoin_ImplicitXORJoin_ReturnsTrue() {
+        // Create the elements and arcs
+        ModelElementContainer container = new ModelElementContainer();
+        TransitionModel t1 = new TransitionModel(CreationMap.createMap());
+        t1.setId("t1");
+        TransitionModel t2 = new TransitionModel(CreationMap.createMap());
+        t2.setId("t2");
+        TransitionModel t3 = new TransitionModel(CreationMap.createMap());
+        t3.setId("t3");
+        PlaceModel p1 = new PlaceModel(CreationMap.createMap());
+        p1.setId("p1");
+        DemoArcModelData a1 = new DemoArcModelData("a1", "t1", "p1", 1);
+        DemoArcModelData a2 = new DemoArcModelData("a2", "t2", "p1", 1);
+        DemoArcModelData a3 = new DemoArcModelData("a3", "p1", "t3", 1);
+
+        // Build the net
+        container.addElement(t1);
+        container.addElement(t2);
+        container.addElement(t3);
+        container.addElement(p1);
+        container.addReference(a1.arc);
+        container.addReference(a2.arc);
+        container.addReference(a3.arc);
+
+        assertTrue(YAWLExportUtils.isImplicitXORJoin(t3));
+    }
+
+    @Test
+    public void isImplicitXORJoin_NoImplicitXORJoin_ReturnsFalse() {
+        // Create the elements and arcs
+        ModelElementContainer container = new ModelElementContainer();
+        TransitionModel t1 = new TransitionModel(CreationMap.createMap());
+        t1.setId("t1");
+        TransitionModel t2 = new TransitionModel(CreationMap.createMap());
+        PlaceModel p1 = new PlaceModel(CreationMap.createMap());
+        p1.setId("p1");
+        DemoArcModelData a1 = new DemoArcModelData("a1", "t1", "p1", 1);
+        DemoArcModelData a2 = new DemoArcModelData("a2", "p1", "t2", 1);
+
+        // Build the net
+        container.addElement(t1);
+        container.addElement(t2);
+        container.addElement(p1);
+        container.addReference(a1.arc);
+        container.addReference(a2.arc);
+
+        assertFalse(YAWLExportUtils.isImplicitXORJoin(t2));
+    }
+
+    @Test
+    public void isImplicitANDSplit_ImplicitANDSplit_ReturnsTrue() {
+        // Create the elements and arcs
+        ModelElementContainer container = new ModelElementContainer();
+        TransitionModel t1 = new TransitionModel(CreationMap.createMap());
+        t1.setId("t1");
+        PlaceModel p1 = new PlaceModel(CreationMap.createMap());
+        p1.setId("p1");
+        PlaceModel p2 = new PlaceModel(CreationMap.createMap());
+        p2.setId("p2");
+        DemoArcModelData a1 = new DemoArcModelData("a1", "t1", "p1", 1);
+        DemoArcModelData a2 = new DemoArcModelData("a2", "t1", "p2", 1);
+
+        // Build the net
+        container.addElement(t1);
+        container.addElement(p1);
+        container.addElement(p2);
+        container.addReference(a1.arc);
+        container.addReference(a2.arc);
+
+        assertTrue(YAWLExportUtils.isImplicitANDSplit(t1));
+    }
+
+    @Test
+    public void isImplicitANDSplit_NoImplicitANDSplit_ReturnsFalse() {
+        // Create the elements and arcs
+        ModelElementContainer container = new ModelElementContainer();
+        TransitionModel t1 = new TransitionModel(CreationMap.createMap());
+        t1.setId("t1");
+        PlaceModel p1 = new PlaceModel(CreationMap.createMap());
+        p1.setId("p1");
+        DemoArcModelData a1 = new DemoArcModelData("a1", "t1", "p1", 1);
+
+        // Build the net
+        container.addElement(t1);
+        container.addElement(p1);
+        container.addReference(a1.arc);
+
+        assertFalse(YAWLExportUtils.isImplicitANDSplit(t1));
+    }
+
+    @Test
+    public void isImplicitANDJoin_ImplicitANDJoin_ReturnsTrue() {
+        // Create the elements and arcs
+        ModelElementContainer container = new ModelElementContainer();
+        TransitionModel t1 = new TransitionModel(CreationMap.createMap());
+        t1.setId("t1");
+        PlaceModel p1 = new PlaceModel(CreationMap.createMap());
+        p1.setId("p1");
+        PlaceModel p2 = new PlaceModel(CreationMap.createMap());
+        p2.setId("p2");
+        DemoArcModelData a1 = new DemoArcModelData("a1", "p1", "t1", 1);
+        DemoArcModelData a2 = new DemoArcModelData("a2", "p2", "t1", 1);
+
+        // Build the net
+        container.addElement(t1);
+        container.addElement(p1);
+        container.addElement(p2);
+        container.addReference(a1.arc);
+        container.addReference(a2.arc);
+
+        assertTrue(YAWLExportUtils.isImplicitANDJoin(t1));
+    }
+
+    @Test
+    public void isImplicitANDJoin_NoImplicitANDJoin_ReturnsFalse() {
+        // Create the elements and arcs
+        ModelElementContainer container = new ModelElementContainer();
+        TransitionModel t1 = new TransitionModel(CreationMap.createMap());
+        t1.setId("t1");
+        PlaceModel p1 = new PlaceModel(CreationMap.createMap());
+        p1.setId("p1");
+        DemoArcModelData a1 = new DemoArcModelData("a1", "p1", "t1", 1);
+
+        // Build the net
+        container.addElement(t1);
+        container.addElement(p1);
+        container.addReference(a1.arc);
+
+        assertFalse(YAWLExportUtils.isImplicitANDJoin(t1));
+    }
+
+    @Test
+    public void getNextElements_TransitionWithExplicitPlaces_ReturnsPlaces() {
+        // Create the elements and arcs
+        ModelElementContainer container = new ModelElementContainer();
+        TransitionModel t1 = new TransitionModel(CreationMap.createMap());
+        t1.setId("t1");
+        PlaceModel p1 = new PlaceModel(CreationMap.createMap());
+        p1.setId("p1");
+        PlaceModel p2 = new PlaceModel(CreationMap.createMap());
+        p2.setId("p2");
+
+        DefaultPort port1 = mock(DefaultPort.class);
+        when(port1.getParent()).thenReturn(p1);
+
+        ArcModel arc1 = mock(ArcModel.class);
+        when(arc1.getId()).thenReturn("arc1");
+        when(arc1.getSourceId()).thenReturn(t1.getId());
+        when(arc1.getTargetId()).thenReturn(p1.getId());
+        when(arc1.getTarget()).thenReturn(port1);
+
+        DefaultPort port2 = mock(DefaultPort.class);
+        when(port2.getParent()).thenReturn(p2);
+
+        ArcModel arc2 = mock(ArcModel.class);
+        when(arc2.getId()).thenReturn("arc2");
+        when(arc2.getSourceId()).thenReturn(t1.getId());
+        when(arc2.getTargetId()).thenReturn(p2.getId());
+        when(arc2.getTarget()).thenReturn(port2);
+
+        // Build the net
+        container.addElement(t1);
+        container.addElement(p1);
+        container.addElement(p2);
+        container.addReference(arc1);
+        container.addReference(arc2);
+
+        ConfigurationManager.getConfiguration().setYAWLExportExplicitPlaces(true);
+
+        Collection<AbstractPetriNetElementModel> nextElements = YAWLExportUtils.getNextElements(t1);
+        List<AbstractPetriNetElementModel> nextElementsList = new ArrayList<>(nextElements);
+
+        assertEquals("p1", nextElementsList.get(0).getId());
+        assertEquals("p2", nextElementsList.get(1).getId());
+    }
+
+    @Test
+    public void getNextElements_TransitionWithImplicitPlaces_ReturnsTransitions() {
+        // Create the elements and arcs
+        ModelElementContainer container = new ModelElementContainer();
+        TransitionModel t1 = new TransitionModel(CreationMap.createMap());
+        t1.setId("t1");
+        PlaceModel p1 = new PlaceModel(CreationMap.createMap());
+        p1.setId("p1");
+        TransitionModel t2 = new TransitionModel(CreationMap.createMap());
+        t2.setId("t2");
+        TransitionModel t3 = new TransitionModel(CreationMap.createMap());
+        t3.setId("t3");
+
+        DefaultPort port1 = mock(DefaultPort.class);
+        when(port1.getParent()).thenReturn(p1);
+
+        ArcModel arc1 = mock(ArcModel.class);
+        when(arc1.getId()).thenReturn("arc1");
+        when(arc1.getSourceId()).thenReturn(t1.getId());
+        when(arc1.getTargetId()).thenReturn(p1.getId());
+        when(arc1.getTarget()).thenReturn(port1);
+
+        DefaultPort port2 = mock(DefaultPort.class);
+        when(port2.getParent()).thenReturn(t2);
+
+        ArcModel arc2 = mock(ArcModel.class);
+        when(arc2.getId()).thenReturn("arc2");
+        when(arc2.getSourceId()).thenReturn(p1.getId());
+        when(arc2.getTargetId()).thenReturn(t2.getId());
+        when(arc2.getTarget()).thenReturn(port2);
+
+        DefaultPort port3 = mock(DefaultPort.class);
+        when(port3.getParent()).thenReturn(t2);
+
+        ArcModel arc3 = mock(ArcModel.class);
+        when(arc3.getId()).thenReturn("arc3");
+        when(arc3.getSourceId()).thenReturn(p1.getId());
+        when(arc3.getTargetId()).thenReturn(t3.getId());
+        when(arc3.getTarget()).thenReturn(port3);
+
+        // Build the net
+        container.addElement(t1);
+        container.addElement(t2);
+        container.addElement(t3);
+        container.addElement(p1);
+        container.addReference(arc1);
+        container.addReference(arc2);
+        container.addReference(arc3);
+
+        ConfigurationManager.getConfiguration().setYAWLExportExplicitPlaces(false);
+
+        Collection<AbstractPetriNetElementModel> nextElements = YAWLExportUtils.getNextElements(t1);
+        List<AbstractPetriNetElementModel> nextElementsList = new ArrayList<>(nextElements);
+
+        assertEquals("t3", nextElementsList.get(0).getId());
+        assertEquals("t2", nextElementsList.get(1).getId());
+    }
+
+    // DemoArcModelData from PNMLExportTest
+    private class DemoArcModelData {
+
+        String id;
+        String sourceId;
+        String targetId;
+        ArcModel arc;
+        int weight;
+        Point2D[] points;
+        Point2D labelPosition;
+
+        DemoArcModelData() {
+            this("a1", "p1", "t1", 2);
+        }
+
+        DemoArcModelData(String id, String sourceId, String targetId, int weight) {
+
+            this.id = id;
+            this.sourceId = sourceId;
+            this.weight = weight;
+            this.targetId = targetId;
+            points = new Point2D[0];
+            labelPosition = new Point2D.Double(0, 0);
+
+            arc = mock(ArcModel.class);
+            when(arc.getInscriptionValue()).thenReturn(this.weight);
+            when(arc.getWeightLabelPosition()).thenReturn(new Point2D.Double(0, 0));
+            when(arc.getId()).thenReturn(this.id);
+            when(arc.getSourceId()).thenReturn(this.sourceId);
+            when(arc.getTargetId()).thenReturn(this.targetId);
+            when(arc.getPoints()).thenReturn(points);
+            when(arc.getProbabilityLabelPosition()).thenReturn(labelPosition);
+            when(arc.getUnknownToolSpecs()).thenReturn(new Vector<>(0));
+        }
+    }
+}


### PR DESCRIPTION
Hinzufuegen von Klassen fuer den YAWLExport. Erweiterung der
Einstellungen durch "YAWL" Tab. Entfernen von YAWL als Dateiformat beim
Oeffnen von Dateien, da nicht unterstuetzt.
Issue: #120