### PR TITLE
Unit test failures in P2TUITest concealed by running in German, revealed in English

### DIFF
--- a/WoPeD-FileInterface/src/test/java/org/woped/file/p2t/P2TUITest.java
+++ b/WoPeD-FileInterface/src/test/java/org/woped/file/p2t/P2TUITest.java
@@ -21,9 +21,8 @@ public class P2TUITest {
     // This method is called before each test
     @BeforeEach
     public void setUp() {
-        p2tui = new P2TUI();
-
         initializeMockMessages();
+        p2tui = new P2TUI();
     }
 
     // This method initializes the mock for the Messages class
@@ -37,6 +36,7 @@ public class P2TUITest {
         messagesMock.when(() -> Messages.getString("P2T.prompt.checkbox.enable.title")).thenReturn("Bearbeitung aktivieren");
         messagesMock.when(() -> Messages.getString("P2T.get.GPTmodel.title")).thenReturn("GPT-Model:");
         messagesMock.when(() -> Messages.getString("P2T.popup.show.again.title")).thenReturn("Erneut anzeigen");
+        messagesMock.when(() -> Messages.getString("P2T.fetchmodels.button")).thenReturn("fetchModels");
     }
 
     // This method is called after each test
@@ -183,7 +183,7 @@ public class P2TUITest {
     public void testIsAPIKeyValid_withInvalidKey() {
         String invalidApiKey = "invalidApiKey";
 
-        boolean isValid = p2tui.isAPIKeyValid(invalidApiKey);
+        boolean isValid = P2TUI.isAPIKeyValid(invalidApiKey);
 
         assertFalse(isValid);
     }


### PR DESCRIPTION
## Description

Minor changes to the initialisation of this test case to ensure messages are initialised correctly. Test failures in `testInitialize()` and initializeSwitchButtonPanel()` occurred when running locally with English language messages. The default in other environments is presumably German.

## Checklist

- [ X] Code has been tested locally
- [ X] All existing tests pass
- [ X] Changes are documented
- [ X] PR adheres to the [contributing guidelines](.github/contributing.md)
- [ ] Reviewers have been assigned   - no, not clear how to assign a reviewer or whether that is relevant to WoPeD development.

## Additional Notes

This was just a minor unit test failure I noticed when building from main locally.
